### PR TITLE
cleanup: use constants in auth middleware

### DIFF
--- a/src/auth/openshift.go
+++ b/src/auth/openshift.go
@@ -15,6 +15,23 @@ import (
 	"os"
 )
 
+const (
+	httpXCSRFTokenHeader    = "X-CSRF-Token"
+	httpLocationHeader      = "Location"
+	httpAuthorizationHeader = "Authorization"
+	httpBearerTokenPrefix   = "Bearer"
+	stateToken              = "state"
+	keyCodeParam            = "code"
+)
+
+const (
+	envInsecureSkipVerify = "INSECURE_SKIP_VERIFY"
+	envKubeClientID       = "KUBE_CLIENT_ID"
+	envKubeAuthURL        = "KUBE_AUTH_URL"
+	envKubeTokenURL       = "KUBE_TOKEN_URL"
+	envKubeUserInfoURL    = "KUBE_USERINFO_URL"
+)
+
 // OpenshiftUserInfo represents the structure of the user info response from OpenShift.
 type OpenshiftUserInfo struct {
 	Metadata struct {
@@ -26,10 +43,10 @@ type OpenshiftUserInfo struct {
 // It returns the access token on success, or an error on failure.
 // This code was taken from https://gist.github.com/kadel/c30b3085e2e90a93393b99a2b39f4806, with minor adjustments.
 func ObtainOpenshiftToken(username, password string, logger *zap.Logger, ctx *gin.Context) (string, error) {
-	skipTlsVerify, err := utils.GetEnvBool("INSECURE_SKIP_VERIFY", true)
+	skipTlsVerify, err := utils.GetEnvBool(envInsecureSkipVerify, true)
 	if err != nil {
-		logger.Error("failed to parse INSECURE_SKIP_VERIFY", zap.Error(err))
-		return "", fmt.Errorf("failed to parse INSECURE_SKIP_VERIFY: %v", err)
+		logger.Error(fmt.Sprintf("failed to parse environment variable %q", envInsecureSkipVerify), zap.Error(err))
+		return "", err
 	}
 
 	httpClient := createHTTPClient(skipTlsVerify)
@@ -77,10 +94,10 @@ func ObtainOpenshiftUsername(token string, logger *zap.Logger) (string, error) {
 // getOAuthConfig returns an OAuth2 configuration based on environment variables.
 func getOAuthConfig() *oauth2.Config {
 	return &oauth2.Config{
-		ClientID: os.Getenv("KUBE_CLIENT_ID"),
+		ClientID: os.Getenv(envKubeClientID),
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  os.Getenv("KUBE_AUTH_URL"),
-			TokenURL: os.Getenv("KUBE_TOKEN_URL"),
+			AuthURL:  os.Getenv(envKubeAuthURL),
+			TokenURL: os.Getenv(envKubeTokenURL),
 		},
 	}
 }
@@ -97,9 +114,10 @@ func createHTTPClient(skipTlsVerify bool) *http.Client {
 }
 
 // createCodeHTTPClient creates an HTTP client for requesting the authorization code.
+// It creates a special client used only to request code, using the
+// CheckRedirect field which ensures that it is not following 302 redirects,
+// and the Location header can be parsed to get code from it.
 func createCodeHTTPClient(skipTlsVerify bool) *http.Client {
-	// this is special client used only to request code
-	// CheckRedirect ensures that it is not following 302 redirects and we can parse Location header to get code from it
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -115,13 +133,12 @@ func createCodeHTTPClient(skipTlsVerify bool) *http.Client {
 // createAuthCodeRequest creates an HTTP request for obtaining the authorization code
 // from the authorization URL, using the provided username and password for basic authentication.
 func createAuthCodeRequest(conf *oauth2.Config, username, password string) (*http.Request, error) {
-	// get an url where we can obtain code
-	authCodeUrl := conf.AuthCodeURL("state", oauth2.AccessTypeOffline)
+	authCodeUrl := conf.AuthCodeURL(stateToken, oauth2.AccessTypeOffline)
 	authCodeReq, err := http.NewRequest("GET", authCodeUrl, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth code request: %v", err)
 	}
-	authCodeReq.Header.Set("X-CSRF-Token", "1")
+	authCodeReq.Header.Set(httpXCSRFTokenHeader, "1")
 	authCodeReq.SetBasicAuth(username, password)
 	return authCodeReq, nil
 }
@@ -148,14 +165,14 @@ func checkAuthCodeResponse(authCodeResp *http.Response) error {
 // parseAuthCode parses the authorization code from the Location header
 // of the HTTP response.
 func parseAuthCode(authCodeResp *http.Response) (string, error) {
-	urlLocation, err := url.Parse(authCodeResp.Header.Get("Location"))
+	urlLocation, err := url.Parse(authCodeResp.Header.Get(httpLocationHeader))
 	if err != nil {
-		return "", fmt.Errorf("failed to parse location header: %v", err)
+		return "", fmt.Errorf("failed to parse %q header: %v", httpLocationHeader, err)
 	}
 
-	code := urlLocation.Query().Get("code")
+	code := urlLocation.Query().Get(keyCodeParam)
 	if code == "" {
-		return "", fmt.Errorf("authorization code not found in location header")
+		return "", fmt.Errorf("authorization code not found in %q header", httpLocationHeader)
 	}
 
 	return code, nil
@@ -175,13 +192,13 @@ func exchangeCodeForToken(ctx context.Context, conf *oauth2.Config, code string)
 func fetchOpenshiftUserInfo(token string) (*OpenshiftUserInfo, error) {
 	userInfo := OpenshiftUserInfo{}
 
-	skipTlsVerify, err := utils.GetEnvBool("INSECURE_SKIP_VERIFY", true)
+	skipTlsVerify, err := utils.GetEnvBool(envInsecureSkipVerify, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse INSECURE_SKIP_VERIFY: %v", err)
+		return nil, err
 	}
 
 	httpClient := createHTTPClient(skipTlsVerify)
-	req, err := createUserInfoRequest(token, os.Getenv("KUBE_USERINFO_URL"))
+	req, err := createUserInfoRequest(token, os.Getenv(envKubeUserInfoURL))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user info request: %v", err)
 	}
@@ -209,7 +226,7 @@ func createUserInfoRequest(token, userInfoUrl string) (*http.Request, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user info request: %v", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set(httpAuthorizationHeader, fmt.Sprintf("%s %s", httpBearerTokenPrefix, token))
 
 	return req, nil
 }

--- a/src/auth/openshift_test.go
+++ b/src/auth/openshift_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestObtainOpenshiftToken(t *testing.T) {
-	os.Setenv("INSECURE_SKIP_VERIFY", "true")
-	os.Setenv("KUBE_CLIENT_ID", "clientid")
+	_ = os.Setenv(envInsecureSkipVerify, "true")
+	_ = os.Setenv(envKubeClientID, "clientid")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/auth" {
@@ -34,8 +34,8 @@ func TestObtainOpenshiftToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	os.Setenv("KUBE_AUTH_URL", ts.URL+"/auth")
-	os.Setenv("KUBE_TOKEN_URL", ts.URL+"/token")
+	_ = os.Setenv(envKubeAuthURL, ts.URL+"/auth")
+	_ = os.Setenv(envKubeTokenURL, ts.URL+"/token")
 
 	type args struct {
 		username string
@@ -132,8 +132,8 @@ func TestObtainOpenshiftUsername(t *testing.T) {
 	defer ts.Close()
 
 	// Set environment variables
-	os.Setenv("INSECURE_SKIP_VERIFY", "true")
-	os.Setenv("KUBE_USERINFO_URL", ts.URL+"/apis/user.openshift.io/v1/users/~")
+	_ = os.Setenv(envInsecureSkipVerify, "true")
+	_ = os.Setenv(envKubeUserInfoURL, ts.URL+"/apis/user.openshift.io/v1/users/~")
 
 	type args struct {
 		token string

--- a/src/middleware/auth_middleware_test.go
+++ b/src/middleware/auth_middleware_test.go
@@ -25,8 +25,8 @@ func (m MockTokenProvider) ObtainUsername(token string, logger *zap.Logger) (str
 }
 
 func TestTokenAuthMiddleware(t *testing.T) {
-	os.Setenv("KUBE_API_SERVER", "https://example.com/api")
-	os.Setenv("INSECURE_SKIP_VERIFY", "true")
+	_ = os.Setenv(envKubeAPIServer, "https://example.com/api")
+	_ = os.Setenv(envInsecureSkipVerify, "true")
 
 	logger, _ := zap.NewDevelopment()
 	router := gin.New()
@@ -63,7 +63,7 @@ func TestTokenAuthMiddleware(t *testing.T) {
 	}{
 		"ShouldSuccessWithValidToken": {
 			args: args{
-				authHeader: "Bearer valid_token",
+				authHeader: httpBearerTokenPrefix + " valid_token",
 			},
 			want: want{
 				expectedStatus: http.StatusOK,
@@ -91,7 +91,7 @@ func TestTokenAuthMiddleware(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/ping", nil)
 			if tc.args.authHeader != "" {
-				req.Header.Set("Authorization", tc.args.authHeader)
+				req.Header.Set(httpAuthorizationHeader, tc.args.authHeader)
 			}
 
 			w := httptest.NewRecorder()

--- a/src/utils/env.go
+++ b/src/utils/env.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 )
@@ -15,7 +16,7 @@ func GetEnvBool(key string, defaultValue bool) (bool, error) {
 
 	valBool, err := strconv.ParseBool(valStr)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse %q", valStr)
 	}
 
 	return valBool, nil


### PR DESCRIPTION
Fixes #11. This PR makes some minor changes to the middleware, using more constants in various functions.