### PR TITLE
fix: add timeout in http client tests

### DIFF
--- a/src/auth/openshift.go
+++ b/src/auth/openshift.go
@@ -5,14 +5,16 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/dana-team/platform-backend/src/utils"
-	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"time"
+
+	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -110,6 +112,7 @@ func createHTTPClient(skipTlsVerify bool) *http.Client {
 				InsecureSkipVerify: skipTlsVerify,
 			},
 		},
+		Timeout: 5 * time.Minute,
 	}
 }
 
@@ -127,6 +130,7 @@ func createCodeHTTPClient(skipTlsVerify bool) *http.Client {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
+		Timeout: 5 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
An attempt to resolve failures of auth
tests by increasing the timeout of http
clients.

Issue #22.