### PR TITLE
docs: add token and configmaps design

### DIFF
--- a/docs/api/configmaps.md
+++ b/docs/api/configmaps.md
@@ -1,0 +1,16 @@
+# ConfigMaps Management API
+
+- **GET** `/v1/namespaces/{namespace}/{configMapName}`
+  - **Description**: Gets data from the specified config map.
+  - **Path Parameter**:
+    - `namespace` - The namespace of the config map.
+    - `configMapName` - The name of the config map.
+  - **Response**: Data of the config map.
+    ```json
+    {
+      "data": {
+        "key": "string",
+        "key1": "string"
+      }
+    }
+    ```

--- a/docs/api/token.md
+++ b/docs/api/token.md
@@ -1,0 +1,34 @@
+# Token Management API
+
+- **POST** `/v1/namespaces/{namespace}/serviceaccounts`
+  - **Description**: Creates a new service account.
+  - **Path Parameter**:
+    - `namespace` - The namespace of the service account.
+  - **Body**:
+    ```json
+    {
+      "serviceAccountName": "string"
+    }
+    ```
+  - **Response**: Confirmation of creation or an error message.
+    ```json
+    {
+      "serviceAccountName": "string",
+    }
+    ```
+
+- **GET** `/v1/namespaces/{namespace}/token`
+  - **Description**: Gets a new token from the service account.
+  - **Path Parameter**:
+    - `namespace` - The namespace of the service account to create token from.
+  - **Body**:
+    ```json
+    {
+      "serviceAccountName": "string"
+    }
+  - **Response**: Token from the created service account.
+    ```json
+    {
+      "token": "string",
+    }
+    ```


### PR DESCRIPTION
Add a new Token and ConfigMap API design.

- `Token` will generate a new token from the service account.
- `ConfigMap` will get data of a specific config map.