### PR TITLE
fix: dotenv error failure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	if err := godotenv.Load(); err != nil {
-		log.Fatalf("Error loading .env file")
+		log.Println("Failed to load .env file")
 	}
 
 	logger := initializeLogger()


### PR DESCRIPTION
We shouldn't throw an error if `.env` is not found. It's an optional file and used only for development purposes.