### PR TITLE
fix: use k8s error bad request

### DIFF
--- a/src/routes/v1/secret_test.go
+++ b/src/routes/v1/secret_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCreateSecret(t *testing.T) {
 	secretRequest := types.CreateSecretRequest{
-		Type:       "Opaque",
+		Type:       "opaque",
 		SecretName: "new-secret",
 		Data:       []types.KeyValue{{Key: "key1", Value: "ZmFrZQ=="}},
 	}

--- a/src/types/secret.go
+++ b/src/types/secret.go
@@ -1,7 +1,7 @@
 package types
 
 type CreateSecretRequest struct {
-	Type       string     `json:"type" binding:"required"`
+	Type       string     `json:"type" binding:"required" enum:"tls,opaque"`
 	SecretName string     `json:"secretName" binding:"required"`
 	Cert       string     `json:"cert"`
 	Key        string     `json:"key"`


### PR DESCRIPTION
Use k8s error in order to avoid such errors:
```
interface conversion: error is *errors.errorString, not *errors.StatusError
```
Which caused by validating the request parameters.