### PR TITLE
fix: update secret endpoint

### DIFF
--- a/src/controllers/common.go
+++ b/src/controllers/common.go
@@ -2,6 +2,8 @@ package controllers
 
 import "github.com/dana-team/platform-backend/src/types"
 
+// convertKeyValueToMap converts a slice of KeyValue pairs to a map
+// with string keys and values.
 func convertKeyValueToMap(kvList []types.KeyValue) map[string]string {
 	values := make(map[string]string)
 	for _, kv := range kvList {
@@ -10,10 +12,22 @@ func convertKeyValueToMap(kvList []types.KeyValue) map[string]string {
 	return values
 }
 
+// convertMapToKeyValue converts a map with string keys and values
+// to a slice of KeyValue pairs.
 func convertMapToKeyValue(values map[string]string) []types.KeyValue {
 	var kvList []types.KeyValue
 	for k, v := range values {
 		kvList = append(kvList, types.KeyValue{Key: k, Value: v})
 	}
 	return kvList
+}
+
+// convertKeyValueToByteMap converts a slice of KeyValue pairs
+// to a map with string keys and byte slice values.
+func convertKeyValueToByteMap(kvList []types.KeyValue) map[string][]byte {
+	data := map[string][]byte{}
+	for _, kv := range kvList {
+		data[kv.Key] = []byte(kv.Value)
+	}
+	return data
 }

--- a/src/controllers/secret.go
+++ b/src/controllers/secret.go
@@ -133,17 +133,14 @@ func (n *secretController) GetSecret(namespace, name string) (types.GetSecretRes
 func (n *secretController) UpdateSecret(namespace, name string, request types.UpdateSecretRequest) (types.UpdateSecretResponse, error) {
 	n.logger.Debug(fmt.Sprintf("Trying to update an existing secret in %q namespace", namespace))
 
-	newSecret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{},
+	secret, err := n.client.CoreV1().Secrets(namespace).Get(n.ctx, name, metav1.GetOptions{})
+	if err != nil {
+		n.logger.Error(fmt.Sprintf("Could not get secret %q with error: %v", name, err.Error()))
+		return types.UpdateSecretResponse{}, err
 	}
-	for _, kv := range request.Data {
-		newSecret.Data[kv.Key] = []byte(kv.Value)
-	}
-	result, err := n.client.CoreV1().Secrets(namespace).Update(n.ctx, newSecret, metav1.UpdateOptions{})
+	secret.Data = convertKeyValueToByteMap(request.Data)
+
+	result, err := n.client.CoreV1().Secrets(namespace).Update(n.ctx, secret, metav1.UpdateOptions{})
 	if err != nil {
 		n.logger.Error(fmt.Sprintf("Could not update secret %q with error: %v", name, err.Error()))
 		return types.UpdateSecretResponse{}, err


### PR DESCRIPTION
Currently, when user calls to update secret endpoint, it creates a new secret with a new updated data. instead, it should get an existing secret and update the data of it.