### PR TITLE
fix: change labelSelector underlying struct to be string

### DIFF
--- a/docs/api/capp.md
+++ b/docs/api/capp.md
@@ -13,7 +13,7 @@ This document outlines the CRUD (Create, Read, Update, Delete) on Capp.
   - **Query Params**:
     - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
     - `continue`: (optional) Used for fetching the next set of results.
-    - `labels`: (optional) Used for filtering namespaces by labels.
+    - `labelSelector`: (optional) Used for filtering by labels.
   - **Response**: Capp names or an error message.
     ```json
     {

--- a/docs/api/capp_revision.md
+++ b/docs/api/capp_revision.md
@@ -11,7 +11,7 @@ This document outlines the CRUD (Create, Read, Update, Delete) on CappRevision. 
   - **Query Params**:
     - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
     - `continue`: (optional) Used for fetching the next set of results.
-    - `labels`: (optional) Used for filtering namespaces by labels.
+    - `labelSelector`: (optional) Used for filtering by labels.
   - **Response**: Capp revisions or an error message.
     ```json
     {

--- a/src/controllers/capp.go
+++ b/src/controllers/capp.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/types"
@@ -88,11 +89,9 @@ func (c *cappController) GetCapps(namespace string, cappQuery types.CappQuery) (
 	c.logger.Debug(fmt.Sprintf("Trying to fetch all capps in namespace: %q", namespace))
 
 	cappList := &v1alpha1.CappList{}
-	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: convertKeyValueToMap(cappQuery.Labels),
-	})
+	selector, err := labels.Parse(cappQuery.LabelSelector)
 	if err != nil {
-		c.logger.Error(fmt.Sprintf("Could not create label selector with error: %v", err.Error()))
+		c.logger.Error(fmt.Sprintf("Could not parse labelSelector with error: %v", err.Error()))
 		return types.CappList{}, err
 	}
 

--- a/src/controllers/capprevision.go
+++ b/src/controllers/capprevision.go
@@ -3,11 +3,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/types"
 	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -49,11 +49,9 @@ func (c *cappRevisionController) GetCappRevisions(namespace string, cappQuery ty
 	c.logger.Debug(fmt.Sprintf("Trying to fetch all capp revisions in namespace: %q", namespace))
 
 	cappRevisionList := &v1alpha1.CappRevisionList{}
-	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: convertKeyValueToMap(cappQuery.Labels),
-	})
+	selector, err := labels.Parse(cappQuery.LabelSelector)
 	if err != nil {
-		c.logger.Error(fmt.Sprintf("Could not create label selector with error: %v", err.Error()))
+		c.logger.Error(fmt.Sprintf("Could not parse labelSelector with error: %v", err.Error()))
 		return types.CappRevisionList{}, err
 	}
 

--- a/src/controllers/common.go
+++ b/src/controllers/common.go
@@ -1,6 +1,8 @@
 package controllers
 
-import "github.com/dana-team/platform-backend/src/types"
+import (
+	"github.com/dana-team/platform-backend/src/types"
+)
 
 // convertKeyValueToMap converts a slice of KeyValue pairs to a map
 // with string keys and values.

--- a/src/routes/v1/capprevision.go
+++ b/src/routes/v1/capprevision.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func cappRevisionHandler(handler func(controller controllers.CappRevisionController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
@@ -47,8 +47,8 @@ func cappRevisionHandler(handler func(controller controllers.CappRevisionControl
 
 func GetCappRevisions() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var cappUri types.CappRevisionNamespaceUri
-		if err := c.BindUri(&cappUri); err != nil {
+		var cappRevisionUri types.CappRevisionNamespaceUri
+		if err := c.BindUri(&cappRevisionUri); err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
 			return
 		}
@@ -59,7 +59,7 @@ func GetCappRevisions() gin.HandlerFunc {
 		}
 
 		cappRevisionHandler(func(controller controllers.CappRevisionController, c *gin.Context) (interface{}, error) {
-			return controller.GetCappRevisions(cappUri.NamespaceName, cappRevisionQuery)
+			return controller.GetCappRevisions(cappRevisionUri.NamespaceName, cappRevisionQuery)
 		})(c)
 	}
 }

--- a/src/types/capp.go
+++ b/src/types/capp.go
@@ -30,7 +30,7 @@ type UpdateCapp struct {
 }
 
 type CappQuery struct {
-	Labels []KeyValue `form:"labels"`
+	LabelSelector string `form:"labelSelector"`
 }
 
 type CappList struct {

--- a/src/types/capprevision.go
+++ b/src/types/capprevision.go
@@ -27,5 +27,5 @@ type CappRevisionUri struct {
 }
 
 type CappRevisionQuery struct {
-	Labels []KeyValue `form:"labels"`
+	LabelSelector string `form:"labelSelector"`
 }


### PR DESCRIPTION
With this change, labelSelectors can now be used on Capp and CappRevisions by using the "?labelSelector=key=value" query parameter. Previously the underlying struct was a nested struct which provided irregular behavior and complicated testing.