### PR TITLE
refactor: change capprevisions list to only return names

### DIFF
--- a/docs/api/capp_revision.md
+++ b/docs/api/capp_revision.md
@@ -12,10 +12,10 @@ This document outlines the CRUD (Create, Read, Update, Delete) on CappRevision. 
     - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
     - `continue`: (optional) Used for fetching the next set of results.
     - `labelSelector`: (optional) Used for filtering by labels.
-  - **Response**: Capp revisions or an error message.
+  - **Response**: CappRevision names or an error message.
     ```json
     {
-       "cappRevisions": []CappRevision,
+       "cappRevisions": []str,
        "count": int
     }
     ```

--- a/src/controllers/capprevision.go
+++ b/src/controllers/capprevision.go
@@ -13,10 +13,10 @@ import (
 )
 
 type CappRevisionController interface {
-	// GetCappRevisions gets all container app revisions from a specific namespace.
+	// GetCappRevisions gets all CappRevision names and count from a specific namespace.
 	GetCappRevisions(namespace string, cappRevisionQuery types.CappRevisionQuery) (types.CappRevisionList, error)
 
-	// GetCappRevision gets a specific container app revision from the specified namespace.
+	// GetCappRevision gets a specific CappRevision from the specified namespace.
 	GetCappRevision(namespace, name string) (types.CappRevision, error)
 }
 
@@ -66,11 +66,15 @@ func (c *cappRevisionController) GetCappRevisions(namespace string, cappQuery ty
 	}
 
 	result := types.CappRevisionList{}
-	result.CappRevisions = append(result.CappRevisions, cappRevisionList.Items...)
+	for _, revision := range cappRevisionList.Items {
+		result.CappRevisions = append(result.CappRevisions, revision.Name)
+	}
 	result.Count = len(cappRevisionList.Items)
+
 	return result, nil
 }
 
+// convertCappRevisionToType converts an API CappRevision to a Type CappRevision.
 func convertCappRevisionToType(cappRevision v1alpha1.CappRevision) types.CappRevision {
 	return types.CappRevision{
 		Metadata: types.Metadata{

--- a/src/routes/v1/capprevision_test.go
+++ b/src/routes/v1/capprevision_test.go
@@ -3,7 +3,6 @@ package v1_test
 import (
 	"encoding/json"
 	"fmt"
-	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/dana-team/platform-backend/src/utils"
 	"github.com/stretchr/testify/assert"
@@ -53,10 +52,7 @@ func TestGetCappRevisions(t *testing.T) {
 			},
 			want: want{
 				statusCode: http.StatusOK,
-				response: types.CappRevisionList{Count: 2, CappRevisions: []cappv1alpha1.CappRevision{
-					utils.GetBareCappRevision(cappRevisionName+"-1", cappRevisionNamespace, map[string]string{labelKey + "-1": labelValue + "-1"}, map[string]string{}),
-					utils.GetBareCappRevision(cappRevisionName+"-2", cappRevisionNamespace, map[string]string{labelKey + "-2": labelValue + "-2"}, map[string]string{}),
-				}},
+				response:   types.CappRevisionList{Count: 2, CappRevisions: []string{cappRevisionName + "-1", cappRevisionName + "-2"}},
 			},
 		},
 		"ShouldFailWithBadRequestInvalidURI": {
@@ -78,9 +74,7 @@ func TestGetCappRevisions(t *testing.T) {
 			},
 			want: want{
 				statusCode: http.StatusOK,
-				response: types.CappRevisionList{Count: 1, CappRevisions: []cappv1alpha1.CappRevision{
-					utils.GetBareCappRevision(cappRevisionName+"-1", cappRevisionNamespace, map[string]string{labelKey + "-1": labelValue + "-1"}, map[string]string{}),
-				}},
+				response:   types.CappRevisionList{Count: 1, CappRevisions: []string{cappRevisionName + "-1"}},
 			},
 		},
 		"ShouldFailGettingCappRevisionsWithInvalidLabelSelector": {
@@ -106,7 +100,7 @@ func TestGetCappRevisions(t *testing.T) {
 			},
 			want: want{
 				statusCode: http.StatusOK,
-				response:   types.CappRevisionList{Count: 0, CappRevisions: []cappv1alpha1.CappRevision{}},
+				response:   types.CappRevisionList{Count: 0, CappRevisions: nil},
 			},
 		},
 	}
@@ -134,10 +128,7 @@ func TestGetCappRevisions(t *testing.T) {
 				}
 
 				assert.Equal(t, test.want.response.Count, response.Count)
-				for i, revision := range test.want.response.CappRevisions {
-					assert.Equal(t, revision.Name, response.CappRevisions[i].Name)
-					assert.Equal(t, revision.Namespace, response.CappRevisions[i].Namespace)
-				}
+				assert.Equal(t, test.want.response.CappRevisions, response.CappRevisions)
 			}
 		})
 	}

--- a/src/types/capprevision.go
+++ b/src/types/capprevision.go
@@ -13,8 +13,8 @@ type CappRevision struct {
 }
 
 type CappRevisionList struct {
-	CappRevisions []cappv1alpha1.CappRevision `json:"capprevisions"`
-	Count         int                         `json:"count"`
+	CappRevisions []string `json:"capprevisions"`
+	Count         int      `json:"count"`
 }
 
 type CappRevisionNamespaceUri struct {


### PR DESCRIPTION
Closes #52. This PR introduces a change to CappRevisions, and now in list operations only the names of the revisions is returned instead of the entire object.