### PR TITLE
refactor: change get capps to only return names of capps

### DIFF
--- a/src/controllers/capp.go
+++ b/src/controllers/capp.go
@@ -13,19 +13,19 @@ import (
 )
 
 type CappController interface {
-	// CreateCapp creates a new container app in the specified namespace.
+	// CreateCapp creates a new Capp in the specified namespace.
 	CreateCapp(namespace string, capp types.CreateCapp) (types.Capp, error)
 
-	// GetCapps gets all container apps from a specific namespace.
+	// GetCapps gets all Capps from a specific namespace.
 	GetCapps(namespace string, cappQuery types.CappQuery) (types.CappList, error)
 
-	// GetCapp gets a specific container app from the specified namespace.
+	// GetCapp gets a specific Capp from the specified namespace.
 	GetCapp(namespace, name string) (types.Capp, error)
 
-	// UpdateCapp updates a specific container app in the specified namespace.
+	// UpdateCapp updates a specific Capp in the specified namespace.
 	UpdateCapp(namespace, name string, capp types.UpdateCapp) (types.Capp, error)
 
-	// DeleteCapp deletes a specific container app in the specified namespace.
+	// DeleteCapp deletes a specific Capp in the specified namespace.
 	DeleteCapp(namespace, name string) (types.CappError, error)
 }
 
@@ -106,7 +106,7 @@ func (c *cappController) GetCapps(namespace string, cappQuery types.CappQuery) (
 
 	result := types.CappList{}
 	for _, item := range cappList.Items {
-		result.Capps = append(result.Capps, convertCappToType(item))
+		result.Capps = append(result.Capps, item.Name)
 	}
 	result.Count = len(cappList.Items)
 	return result, nil

--- a/src/types/capp.go
+++ b/src/types/capp.go
@@ -34,8 +34,8 @@ type CappQuery struct {
 }
 
 type CappList struct {
-	Capps []Capp `json:"capps"`
-	Count int    `json:"count"`
+	Capps []string `json:"capps"`
+	Count int      `json:"count"`
 }
 
 type CappNamespaceUri struct {


### PR DESCRIPTION
Closes #51. With this change, now only a set of names of Capps is returned when fetching all the Capps in a namespace.