### PR TITLE
tests: add unit testing for the capp controller

### DIFF
--- a/src/controllers/capp_test.go
+++ b/src/controllers/capp_test.go
@@ -1,0 +1,357 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	cappv1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"testing"
+)
+
+func TestGetCapp(t *testing.T) {
+	namespaceName := testutils.CappNamespace + "-get"
+
+	type requestParams struct {
+		name      string
+		namespace string
+	}
+
+	type want struct {
+		capp        types.Capp
+		errorStatus metav1.StatusReason
+	}
+
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedGettingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + "-1",
+			},
+			want: want{
+				capp: types.Capp{
+					Metadata: mocks.PrepareCappMetadata(testutils.CappName+"-1", namespaceName),
+					Spec:     mocks.PrepareCappSpec(),
+					Status:   mocks.PrepareCappStatus(testutils.CappName+"-1", namespaceName),
+					Labels:   []types.KeyValue{{Key: testutils.LabelKey + "-1", Value: testutils.LabelValue + "-1"}},
+				},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFailGettingNonExistingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + testutils.NonExistentSuffix,
+			},
+			want: want{
+				capp:        types.Capp{},
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+		"ShouldFailGettingCappInNonExistingNamespace": {
+			requestParams: requestParams{
+				namespace: namespaceName + testutils.NonExistentSuffix,
+				name:      testutils.CappName,
+			},
+			want: want{
+				capp:        types.Capp{},
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+	}
+	setup()
+	cappController := NewCappController(dynClient, context.TODO(), logger)
+	createTestNamespace(namespaceName)
+	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			response, err := cappController.GetCapp(test.requestParams.namespace, test.requestParams.name)
+			if test.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(errors.APIStatus).Status().Reason
+
+				assert.Equal(t, test.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.capp, response)
+		})
+
+	}
+
+}
+
+func TestGetCapps(t *testing.T) {
+	namespaceName := testutils.CappNamespace + "-getmany"
+
+	type requestParams struct {
+		cappQuery types.CappQuery
+		namespace string
+	}
+
+	type want struct {
+		cappList    types.CappList
+		errorStatus metav1.StatusReason
+	}
+
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedGettingAllCappRevisions": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				cappQuery: types.CappQuery{},
+			},
+			want: want{
+				errorStatus: metav1.StatusSuccess,
+				cappList: types.CappList{Count: 2, Capps: []types.CappSummary{
+					mocks.PrepareCappSummary(testutils.CappName+"-1", namespaceName),
+
+					mocks.PrepareCappSummary(testutils.CappName+"-2", namespaceName),
+				},
+				},
+			},
+		},
+		"ShouldSucceedGettingCappByLabels": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				cappQuery: types.CappQuery{LabelSelector: fmt.Sprintf("%s-2=%s-2", testutils.LabelKey, testutils.LabelValue)},
+			},
+			want: want{
+				cappList: types.CappList{Count: 1, Capps: []types.CappSummary{
+					mocks.PrepareCappSummary(testutils.CappName+"-2", namespaceName),
+				},
+				},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFailGettingCappsWithInvalidSelector": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				cappQuery: types.CappQuery{LabelSelector: testutils.InvalidLabelSelector},
+			},
+			want: want{
+				cappList:    types.CappList{},
+				errorStatus: metav1.StatusReasonBadRequest,
+			},
+		},
+		"ShouldFailGettingNonExistingNamespace": {
+			requestParams: requestParams{
+				namespace: namespaceName + testutils.NonExistentSuffix,
+				cappQuery: types.CappQuery{},
+			},
+			want: want{
+				cappList:    types.CappList{},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+	}
+	setup()
+	cappController := NewCappController(dynClient, context.TODO(), logger)
+	createTestNamespace(namespaceName)
+	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
+	mocks.CreateTestCapp(testutils.CappName+"-2", namespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, map[string]string{}, dynClient)
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			response, err := cappController.GetCapps(test.requestParams.namespace, test.requestParams.cappQuery)
+			if test.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(errors.APIStatus).Status().Reason
+
+				assert.Equal(t, test.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.cappList, response)
+		})
+	}
+}
+
+func TestCreateCapp(t *testing.T) {
+	namespaceName := testutils.CappNamespace + "-create"
+	type requestParams struct {
+		capp      types.CreateCapp
+		namespace string
+	}
+
+	type want struct {
+		response    types.Capp
+		errorStatus metav1.StatusReason
+	}
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedCreatingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				capp:      mocks.PrepareCreateCappType(testutils.CappName+"-2", []types.KeyValue{{Key: testutils.LabelKey + "-2", Value: testutils.LabelValue + "-2"}}, nil),
+			},
+			want: want{
+				response: types.Capp{
+					Metadata: mocks.PrepareCappMetadata(testutils.CappName+"-2", namespaceName),
+					Spec:     mocks.PrepareCappSpec(),
+					Status:   cappv1.CappStatus{},
+					Labels:   []types.KeyValue{{Key: testutils.LabelKey + "-2", Value: testutils.LabelValue + "-2"}},
+				},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFailCreatingExistingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				capp:      mocks.PrepareCreateCappType(testutils.CappName+"-1", []types.KeyValue{{Key: testutils.LabelKey + "-1", Value: testutils.LabelValue + "-1"}}, nil),
+			},
+			want: want{
+				response:    types.Capp{},
+				errorStatus: metav1.StatusReasonAlreadyExists,
+			},
+		},
+	}
+	setup()
+	cappController := NewCappController(dynClient, context.TODO(), logger)
+	createTestNamespace(namespaceName)
+	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			response, err := cappController.CreateCapp(test.requestParams.namespace, test.requestParams.capp)
+			if test.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(errors.APIStatus).Status().Reason
+
+				assert.Equal(t, test.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.response, response)
+		})
+	}
+}
+
+func TestUpdateCapp(t *testing.T) {
+	namespaceName := testutils.CappNamespace + "-update"
+	type requestParams struct {
+		name      string
+		capp      types.UpdateCapp
+		namespace string
+	}
+
+	type want struct {
+		response    types.Capp
+		errorStatus metav1.StatusReason
+	}
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedUpdatingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + "-1",
+				capp:      mocks.PrepareUpdateCappType([]types.KeyValue{{Key: testutils.LabelKey + "-3", Value: testutils.LabelValue + "-3"}}, nil),
+			},
+			want: want{
+				response: types.Capp{
+					Metadata: mocks.PrepareCappMetadata(testutils.CappName+"-1", namespaceName),
+					Spec:     mocks.PrepareCappSpec(),
+					Status:   mocks.PrepareCappStatus(testutils.CappName+"-1", namespaceName),
+					Labels:   []types.KeyValue{{Key: testutils.LabelKey + "-3", Value: testutils.LabelValue + "-3"}},
+				},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFaildUpdatingNonExistingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + testutils.NonExistentSuffix,
+				capp:      mocks.PrepareUpdateCappType([]types.KeyValue{{Key: testutils.LabelKey + "-3", Value: testutils.LabelValue + "-3"}}, nil),
+			},
+			want: want{
+				response:    types.Capp{},
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+	}
+	setup()
+	cappController := NewCappController(dynClient, context.TODO(), logger)
+	createTestNamespace(namespaceName)
+	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			response, err := cappController.UpdateCapp(test.requestParams.namespace, test.requestParams.name, test.requestParams.capp)
+			if test.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(errors.APIStatus).Status().Reason
+
+				assert.Equal(t, test.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.response, response)
+		})
+	}
+}
+
+func TestDeleteCapp(t *testing.T) {
+	namespaceName := testutils.CappNamespace + "-delete"
+	type requestParams struct {
+		name      string
+		namespace string
+	}
+	type want struct {
+		response    types.CappError
+		errorStatus metav1.StatusReason
+	}
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedDeletingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + "-1",
+			},
+			want: want{
+				errorStatus: metav1.StatusSuccess,
+				response: types.CappError{
+					Message: fmt.Sprintf("Deleted capp %q in namespace %q successfully", testutils.CappName+"-1", namespaceName),
+				},
+			},
+		},
+		"ShouldFailDeletingNonExistingCapp": {
+			requestParams: requestParams{
+				namespace: namespaceName,
+				name:      testutils.CappName + testutils.NonExistentSuffix,
+			},
+			want: want{
+				errorStatus: metav1.StatusReasonNotFound,
+				response:    types.CappError{},
+			},
+		},
+	}
+	setup()
+	cappController := NewCappController(dynClient, context.TODO(), logger)
+	createTestNamespace(namespaceName)
+	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			response, err := cappController.DeleteCapp(test.requestParams.namespace, test.requestParams.name)
+			if test.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(errors.APIStatus).Status().Reason
+
+				assert.Equal(t, test.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.response, response)
+		})
+	}
+}

--- a/src/controllers/capprevision_test.go
+++ b/src/controllers/capprevision_test.go
@@ -24,7 +24,7 @@ func createTestCappRevision(name, namespace string, labels, annotations map[stri
 }
 
 func TestGetCappRevision(t *testing.T) {
-	namespaceName := testutils.CappRevisionNamespace + "-GetOne"
+	namespaceName := testutils.CappRevisionNamespace + "-get"
 
 	type requestParams struct {
 		name      string
@@ -102,7 +102,7 @@ func TestGetCappRevision(t *testing.T) {
 }
 
 func TestGetCappRevisions(t *testing.T) {
-	namespaceName := testutils.CappRevisionNamespace + "-GetMany"
+	namespaceName := testutils.CappRevisionNamespace + "-getmany"
 
 	type requestParams struct {
 		cappQuery types.CappRevisionQuery
@@ -140,7 +140,7 @@ func TestGetCappRevisions(t *testing.T) {
 		"ShouldThrowErrorWithInvalidSelector": {
 			requestParams: requestParams{
 				namespace: namespaceName,
-				cappQuery: types.CappRevisionQuery{LabelSelector: ":--"},
+				cappQuery: types.CappRevisionQuery{LabelSelector: testutils.InvalidLabelSelector},
 			},
 			want: want{
 				cappRevisions: types.CappRevisionList{},

--- a/src/routes/v1/capp_test.go
+++ b/src/routes/v1/capp_test.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
@@ -16,24 +15,6 @@ import (
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/stretchr/testify/assert"
 )
-
-// createTestCapp creates a test Capp object.
-func createTestCapp(name, namespace string, labels, annotations map[string]string) {
-	capp := mocks.PrepareCapp(name, namespace, labels, annotations)
-	err := dynClient.Create(context.TODO(), &capp)
-	if err != nil {
-		panic(err)
-	}
-}
-
-// createTestCapp creates a test Capp object.
-func createTestCappWithHostname(name, namespace string, labels, annotations map[string]string) {
-	capp := mocks.PrepareCappWithHostname(name, namespace, labels, annotations)
-	err := dynClient.Create(context.TODO(), &capp)
-	if err != nil {
-		panic(err)
-	}
-}
 
 func TestGetCapps(t *testing.T) {
 	testNamespaceName := testutils.CappNamespace + "-get"
@@ -128,10 +109,10 @@ func TestGetCapps(t *testing.T) {
 
 	setup()
 	createTestNamespace(testNamespaceName)
-	createTestCapp(testutils.CappName+"-1", testNamespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, nil)
-	createTestCapp(testutils.CappName+"-2", testNamespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, nil)
-	createTestCappWithHostname(testutils.CappName+"-3", testNamespaceName, map[string]string{testutils.LabelKey + "-3": testutils.LabelValue + "-3"}, nil)
-	createTestCappWithHostname(testutils.CappName+"-4", testNamespaceName, map[string]string{testutils.LabelKey + "-4": testutils.LabelValue + "-4"}, nil)
+	mocks.CreateTestCapp(testutils.CappName+"-1", testNamespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, nil, dynClient)
+	mocks.CreateTestCapp(testutils.CappName+"-2", testNamespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, nil, dynClient)
+	mocks.CreateTestCappWithHostname(testutils.CappName+"-3", testNamespaceName, map[string]string{testutils.LabelKey + "-3": testutils.LabelValue + "-3"}, nil, dynClient)
+	mocks.CreateTestCappWithHostname(testutils.CappName+"-4", testNamespaceName, map[string]string{testutils.LabelKey + "-4": testutils.LabelValue + "-4"}, nil, dynClient)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -227,7 +208,7 @@ func TestGetCapp(t *testing.T) {
 
 	setup()
 	createTestNamespace(testNamespaceName)
-	createTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil)
+	mocks.CreateTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil, dynClient)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -317,7 +298,7 @@ func TestCreateCapp(t *testing.T) {
 
 	setup()
 	createTestNamespace(testNamespaceName)
-	createTestCapp(testutils.CappName+"-1", testNamespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, nil)
+	mocks.CreateTestCapp(testutils.CappName+"-1", testNamespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, nil, dynClient)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -414,7 +395,7 @@ func TestUpdateCapp(t *testing.T) {
 	}
 
 	setup()
-	createTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil)
+	mocks.CreateTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil, dynClient)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -503,7 +484,7 @@ func TestDeleteCapp(t *testing.T) {
 	}
 
 	setup()
-	createTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil)
+	mocks.CreateTestCapp(testutils.CappName, testNamespaceName, map[string]string{testutils.LabelKey: testutils.LabelValue}, nil, dynClient)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -29,9 +29,10 @@ const (
 )
 
 const (
-	LabelSelectorKey = "labelSelector"
-	LabelKey         = "key"
-	LabelValue       = "value"
+	LabelSelectorKey     = "labelSelector"
+	LabelKey             = "key"
+	LabelValue           = "value"
+	InvalidLabelSelector = ":--"
 )
 
 const (

--- a/src/utils/testutils/mocks/capp.go
+++ b/src/utils/testutils/mocks/capp.go
@@ -1,7 +1,9 @@
 package mocks
 
 import (
+	"context"
 	"fmt"
+
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
@@ -10,6 +12,7 @@ import (
 	knativeapis "knative.dev/pkg/apis"
 	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
 	knativev1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // PrepareCapp returns a mock Capp object.
@@ -127,5 +130,38 @@ func PrepareCreateCappType(name string, labels, annotations []types.KeyValue) ty
 		Annotations: annotations,
 		Labels:      labels,
 		Spec:        PrepareCappSpec(),
+	}
+}
+
+func PrepareCappMetadata(name, namespace string) types.Metadata {
+	return types.Metadata{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+func PrepareCappSummary(name string, namespace string) types.CappSummary {
+	return types.CappSummary{
+		Name:   name,
+		Images: []string{testutils.CappImage},
+		URL:    fmt.Sprintf("https://%s-%s.%s", name, namespace, testutils.Domain),
+	}
+}
+
+// CreateTestCapp creates a test Capp object.
+func CreateTestCapp(name, namespace string, labels, annotations map[string]string, dynClient runtimeClient.WithWatch) {
+	cappRevision := PrepareCapp(name, namespace, labels, annotations)
+	err := dynClient.Create(context.TODO(), &cappRevision)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// CreateTestCappWithHostname creates a test Capp object with a hostname.
+func CreateTestCappWithHostname(name, namespace string, labels, annotations map[string]string, dynClient runtimeClient.WithWatch) {
+	capp := PrepareCappWithHostname(name, namespace, labels, annotations)
+	err := dynClient.Create(context.TODO(), &capp)
+	if err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
With this pr, unit tests have been added for the `capp` controller.
Resolves #67 