### PR TITLE
feat: add managed label to resources

### DIFF
--- a/src/controllers/capprevision_test.go
+++ b/src/controllers/capprevision_test.go
@@ -81,7 +81,7 @@ func TestGetCappRevision(t *testing.T) {
 	}
 	setup()
 	cappRevisionController := NewCappRevisionController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	createTestCappRevision(testutils.CappRevisionName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{})
 	createTestCappRevision(testutils.CappRevisionName+"-2", namespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, map[string]string{})
 	for name, test := range cases {
@@ -160,7 +160,7 @@ func TestGetCappRevisions(t *testing.T) {
 	}
 	setup()
 	cappRevisionController := NewCappRevisionController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	createTestCappRevision(testutils.CappRevisionName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{})
 	createTestCappRevision(testutils.CappRevisionName+"-2", namespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, map[string]string{})
 	for name, test := range cases {

--- a/src/controllers/namespace.go
+++ b/src/controllers/namespace.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/dana-team/platform-backend/src/utils"
 
 	"github.com/dana-team/platform-backend/src/types"
 	"go.uber.org/zap"
@@ -36,7 +37,7 @@ func (n *namespaceController) GetNamespaces() (types.NamespaceList, error) {
 	n.logger.Debug("Trying to fetch all namespaces")
 
 	namespaceList := types.NamespaceList{}
-	namespaces, err := n.client.CoreV1().Namespaces().List(n.ctx, metav1.ListOptions{})
+	namespaces, err := n.client.CoreV1().Namespaces().List(n.ctx, metav1.ListOptions{LabelSelector: utils.ManagedLabelSelctor})
 	if err != nil {
 		n.logger.Error(fmt.Sprintf("Could not fetch namespaces with error: %s", err.Error()))
 		return namespaceList, err
@@ -69,6 +70,7 @@ func (n *namespaceController) CreateNamespace(name string) (types.Namespace, err
 
 	newNamespace := v1.Namespace{}
 	newNamespace.Name = name
+	newNamespace.Labels = utils.AddManagedLabel(map[string]string{})
 	namespace, err := n.client.CoreV1().Namespaces().Create(n.ctx, &newNamespace, metav1.CreateOptions{})
 	if err != nil {
 		n.logger.Error(fmt.Sprintf("Could not create namespace %q with error: %s", name, err.Error()))

--- a/src/controllers/secret_test.go
+++ b/src/controllers/secret_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
 	"github.com/stretchr/testify/assert"
@@ -12,8 +13,6 @@ import (
 	"strings"
 	"testing"
 )
-
-const newNamespace = "newNamespace"
 
 func TestGetSecret(t *testing.T) {
 	namespaceName := testutils.SecretNamespace + "-get"
@@ -73,9 +72,9 @@ func TestGetSecret(t *testing.T) {
 	}
 	setup()
 	secretController := NewSecretController(fakeClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
-	createTestSecret(testutils.SecretName+"-1", namespaceName)
-	createTestSecret(testutils.SecretName+"-2", namespaceName)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-1", namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-2", namespaceName, utils.AddManagedLabel(map[string]string{}))
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			response, err := secretController.GetSecret(test.requestParams.namespace, test.requestParams.name)
@@ -128,9 +127,9 @@ func TestGetSecrets(t *testing.T) {
 	}
 	setup()
 	secretController := NewSecretController(fakeClient, context.TODO(), logger)
-	createTestSecret(testutils.SecretName+"-1", namespaceName)
-	createTestSecret(testutils.SecretName+"-2", namespaceName)
-	createTestNamespace(newNamespace)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-1", namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-2", namespaceName, utils.AddManagedLabel(map[string]string{}))
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			response, err := secretController.GetSecrets(test.requestParams.namespace)
@@ -216,9 +215,9 @@ func TestCreateSecret(t *testing.T) {
 	}
 	setup()
 	secretController := NewSecretController(fakeClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
-	createTestSecret(testutils.SecretName+"-1", namespaceName)
-	createTestSecret(testutils.SecretName+"-2", namespaceName)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-1", namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-2", namespaceName, utils.AddManagedLabel(map[string]string{}))
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			response, err := secretController.CreateSecret(test.requestParams.namespace, test.requestParams.request)
@@ -289,9 +288,9 @@ func TestUpdateSecret(t *testing.T) {
 	}
 	setup()
 	secretController := NewSecretController(fakeClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
-	createTestSecret(testutils.SecretName+"-1", namespaceName)
-	createTestSecret(testutils.SecretName+"-2", namespaceName)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-1", namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-2", namespaceName, utils.AddManagedLabel(map[string]string{}))
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			response, err := secretController.UpdateSecret(test.requestParams.namespace, test.requestParams.name, test.requestParams.request)
@@ -345,9 +344,9 @@ func TestDeleteSecret(t *testing.T) {
 	}
 	setup()
 	secretController := NewSecretController(fakeClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
-	createTestSecret(testutils.SecretName+"-1", namespaceName)
-	createTestSecret(testutils.SecretName+"-2", namespaceName)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-1", namespaceName, utils.AddManagedLabel(map[string]string{}))
+	createTestSecret(testutils.SecretName+"-2", namespaceName, utils.AddManagedLabel(map[string]string{}))
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			response, err := secretController.DeleteSecret(test.requestParams.namespace, test.requestParams.name)

--- a/src/controllers/setup_test.go
+++ b/src/controllers/setup_test.go
@@ -33,10 +33,11 @@ func setup() {
 
 }
 
-func createTestNamespace(name string) {
+func createTestNamespace(name string, labels map[string]string) {
 	namespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labels,
 		},
 	}
 	_, err := fakeClient.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
@@ -44,11 +45,12 @@ func createTestNamespace(name string) {
 		panic(err)
 	}
 }
-func createTestSecret(secretName string, namespace string) {
+func createTestSecret(secretName string, namespace string, labels map[string]string) {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{

--- a/src/controllers/users.go
+++ b/src/controllers/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
 	"go.uber.org/zap"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +55,7 @@ func NewUserController(client kubernetes.Interface, context context.Context, log
 func (u *userController) GetUsers(namespace string) (types.UsersOutput, error) {
 	u.logger.Debug(fmt.Sprintf("Trying to get all rolebindings in %q namespace", namespace))
 
-	roleBindings, err := u.client.RbacV1().RoleBindings(namespace).List(u.ctx, metav1.ListOptions{})
+	roleBindings, err := u.client.RbacV1().RoleBindings(namespace).List(u.ctx, metav1.ListOptions{LabelSelector: utils.ManagedLabelSelctor})
 	userOutputs := types.UsersOutput{}
 	if err != nil {
 		u.logger.Error(fmt.Sprintf("Could not get rolebindings with error: %v", err.Error()))
@@ -153,7 +154,8 @@ func (u *userController) DeleteUser(userIdentifier types.UserIdentifier) (types.
 func prepareRoleBinding(roleBindingName string, role string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: roleBindingName,
+			Name:   roleBindingName,
+			Labels: utils.AddManagedLabel(map[string]string{}),
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/src/utils/labels.go
+++ b/src/utils/labels.go
@@ -1,0 +1,13 @@
+package utils
+
+import cappv1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+
+var domain = cappv1.GroupVersion.Group
+var managedLabel = domain + "/managed"
+var ManagedLabelSelctor = managedLabel + "=true"
+
+// AddManagedLabel adds the managed label to the given labels map.
+func AddManagedLabel(labels map[string]string) map[string]string {
+	labels[managedLabel] = "true"
+	return labels
+}

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -1,8 +1,9 @@
 package testutils
 
 const (
-	Domain   = "dana-team.io"
-	Hostname = "custom-capp"
+	Domain       = "dana-team.io"
+	Hostname     = "custom-capp"
+	ManagedLabel = "rcs.dana.io/managed"
 )
 
 const (

--- a/src/utils/testutils/mocks/namespace.go
+++ b/src/utils/testutils/mocks/namespace.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -10,7 +11,8 @@ import (
 func PrepareNamespace(name string) corev1.Namespace {
 	return corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: utils.AddManagedLabel(map[string]string{}),
 		},
 	}
 }

--- a/src/utils/testutils/mocks/secret.go
+++ b/src/utils/testutils/mocks/secret.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,6 +13,7 @@ func PrepareSecret(name, namespace, dataKey, dataValue string) corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{testutils.ManagedLabel: "true"},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{

--- a/src/utils/testutils/mocks/user.go
+++ b/src/utils/testutils/mocks/user.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,6 +18,7 @@ func PrepareRoleBinding(name, namespace, role string) rbacv1.RoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    utils.AddManagedLabel(map[string]string{}),
 		},
 		Subjects: []rbacv1.Subject{
 			{


### PR DESCRIPTION
With this PR, a new label will be added to any resource (namespaces, users, secrets...).
This label will be used when fetching to ensure that default resources will not be displayed or fetched.
Resolves #64 
