### PR TITLE
fix: move scheme creation to main to avoid concurrent writes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
-	"log"
-
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/auth"
 	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/routes/v1"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"log"
 )
 
 func main() {
@@ -46,7 +49,16 @@ func syncLogger(logger *zap.Logger) {
 func initializeRouter(logger *zap.Logger, tokenProvider auth.TokenProvider) *gin.Engine {
 	engine := gin.Default()
 	engine.Use(middleware.LoggerMiddleware(logger))
-	v1.SetupRoutes(engine, tokenProvider)
+	v1.SetupRoutes(engine, tokenProvider, newScheme())
 
 	return engine
+}
+
+// newScheme adds the relevant APIs to the scheme for the K8S client.
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(cappv1alpha1.AddToScheme(scheme))
+
+	return scheme
 }

--- a/src/controllers/capp_test.go
+++ b/src/controllers/capp_test.go
@@ -69,7 +69,7 @@ func TestGetCapp(t *testing.T) {
 	}
 	setup()
 	cappController := NewCappController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestGetCapps(t *testing.T) {
 	}
 	setup()
 	cappController := NewCappController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
 	mocks.CreateTestCapp(testutils.CappName+"-2", namespaceName, map[string]string{testutils.LabelKey + "-2": testutils.LabelValue + "-2"}, map[string]string{}, dynClient)
 	for name, test := range cases {
@@ -217,7 +217,7 @@ func TestCreateCapp(t *testing.T) {
 	}
 	setup()
 	cappController := NewCappController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
 
 	for name, test := range cases {
@@ -281,7 +281,7 @@ func TestUpdateCapp(t *testing.T) {
 	}
 	setup()
 	cappController := NewCappController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
 
 	for name, test := range cases {
@@ -338,7 +338,7 @@ func TestDeleteCapp(t *testing.T) {
 	}
 	setup()
 	cappController := NewCappController(dynClient, context.TODO(), logger)
-	createTestNamespace(namespaceName)
+	createTestNamespace(namespaceName, map[string]string{})
 	mocks.CreateTestCapp(testutils.CappName+"-1", namespaceName, map[string]string{testutils.LabelKey + "-1": testutils.LabelValue + "-1"}, map[string]string{}, dynClient)
 
 	for name, test := range cases {

--- a/src/middleware/auth_middleware_test.go
+++ b/src/middleware/auth_middleware_test.go
@@ -1,6 +1,10 @@
 package middleware
 
 import (
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,7 +42,7 @@ func TestTokenAuthMiddleware(t *testing.T) {
 		c.Next()
 	})
 
-	router.Use(TokenAuthMiddleware(MockTokenProvider{Token: "valid_token", Username: "user", Err: nil}))
+	router.Use(TokenAuthMiddleware(MockTokenProvider{Token: "valid_token", Username: "user", Err: nil}, newScheme()))
 	router.GET("/ping", func(c *gin.Context) {
 		_, ok := c.Get("kubeClient")
 		if !ok {
@@ -109,4 +113,13 @@ func TestTokenAuthMiddleware(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newScheme adds the relevant APIs to the scheme for the K8S client.
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(cappv1alpha1.AddToScheme(scheme))
+
+	return scheme
 }

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 
 	"github.com/dana-team/platform-backend/src/auth"
@@ -8,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
+func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *runtime.Scheme) {
 	v1 := engine.Group("/v1")
 
 	engine.GET("/ping", func(c *gin.Context) {
@@ -23,7 +24,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
 	}
 
 	namespacesGroup := v1.Group("/namespaces")
-	namespacesGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	namespacesGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		namespacesGroup.GET("", GetNamespaces())
 		namespacesGroup.GET("/:namespaceName", GetNamespace())
@@ -32,7 +33,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
 	}
 
 	secretsGroup := namespacesGroup.Group("/:namespaceName/secrets")
-	secretsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	secretsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		secretsGroup.POST("", CreateSecret())
 		secretsGroup.GET("", GetSecrets())
@@ -42,7 +43,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
 	}
 
 	cappGroup := namespacesGroup.Group("/:namespaceName/capps")
-	cappGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	cappGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		cappGroup.POST("", CreateCapp())
 		cappGroup.GET("", GetCapps())
@@ -52,14 +53,14 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
 	}
 
 	cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capprevisions")
-	cappRevisionGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	cappRevisionGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		cappRevisionGroup.GET("", GetCappRevisions())
 		cappRevisionGroup.GET("/:cappRevisionName", GetCappRevision())
 	}
 
 	usersGroup := namespacesGroup.Group("/:namespaceName/users")
-	usersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	usersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		usersGroup.POST("", CreateUser())
 		usersGroup.GET("", GetUsers())
@@ -69,7 +70,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider) {
 	}
 
 	configMapGroup := namespacesGroup.Group("/:namespaceName/configmaps")
-	configMapGroup.Use(middleware.TokenAuthMiddleware(tokenProvider))
+	configMapGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		configMapGroup.GET("/:configMapName", GetConfigMap())
 	}


### PR DESCRIPTION
When concurrent requests were made to the router, it paniced on occasion due to concurrent map writes when adding the capp api to the created scheme. This change moves the scheme creation to main, so that the AddToScheme logic is only done once.