### PR TITLE
build: add liveness and readiness probe

### DIFF
--- a/chart/templates/capp.yaml
+++ b/chart/templates/capp.yaml
@@ -14,4 +14,15 @@ spec:
             image: {{ .Values.image }}
             imagePullPolicy: {{ .Values.imagePullPolicy }}
             name: {{ .Release.Name }}
+            readinessProbe:
+              tcpSocket:
+                port: {{ .Values.readinessProbe.port }}
+              initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            livenessProbe:
+              httpGet:
+                path: {{ .Values.livenessProbe.path }}
+                port: {{ .Values.livenessProbe.port }}
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
   scaleMetric: {{ .Values.scaleMetric }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,4 +24,42 @@ authConfig:
   kubeClientID: openshift-challenging-client
 
 # -- Name of the scale metric to use for Capp
+scaleMetric: concurrency# Default values for logging-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Cluster name where the code is deployed
+clusterName: cluster-test
+
+# -- Domain of the cluster where the code is deployed
+clusterDomain: domain-test.com
+
+# -- Port of the API Server of the cluster
+apiPort: 6443
+
+# -- The image to run the Capp with.
+image: ghcr.io/dana-team/platform-backend:main
+
+# -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
+imagePullPolicy: Always
+
+# -- Name of the ConfigMap where authentication endpoints are stored
+authConfig:
+  name: auth-config
+  insecureSkipVerify: true
+  kubeClientID: openshift-challenging-client
+
+# -- Name of the scale metric to use for Capp
 scaleMetric: concurrency
+
+# -- Readiness and Liveness Probes Configuration
+readinessProbe:
+  port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+livenessProbe:
+  path: /healthz
+  port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -12,10 +12,8 @@ import (
 func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *runtime.Scheme) {
 	v1 := engine.Group("/v1")
 
-	engine.GET("/ping", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "pong",
-		})
+	engine.GET("/healthz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
 	authGroup := v1.Group("/login")

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -92,7 +92,6 @@ const (
 	ContainerName = "capp-container"
 	StateKey      = "state"
 	DisabledState = "disabled"
-	EnabledState  = "enabled"
 )
 
 const (

--- a/test/e2e_tests/capp.go
+++ b/test/e2e_tests/capp.go
@@ -36,7 +36,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 	Context("Validate get Capps route", func() {
 		It("Should get all Capps in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CappsKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
@@ -55,7 +55,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", secondLabelKey, secondLabelValue))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
@@ -73,7 +73,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", testutils.LabelCappName, testutils.InvalidLabelSelector))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("unable to parse requirement: values[0][%s]: Invalid value: %q: "+
@@ -93,7 +93,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", secondLabelKey, secondLabelValue+testutils.NonExistentSuffix))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: nil,
@@ -108,7 +108,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 	Context("Validate get Capp route", func() {
 		It("Should get a specific Capp in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CappsKey, oneCappName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey: types.Metadata{Name: oneCappName, Namespace: namespaceName},
@@ -124,7 +124,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 		It("Should handle a not found Capp in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CappsKey, oneCappName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
@@ -139,7 +139,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 		It("Should handle a get of a Capp in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.CappsKey, oneCappName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName),
@@ -162,7 +162,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey:    types.Metadata{Name: newCappName, Namespace: namespaceName},
 				testutils.LabelsKey:      []types.KeyValue{{Key: testutils.LabelKey, Value: testutils.LabelValue}},
@@ -186,7 +186,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'CreateCapp.Metadata.Name' Error:Field validation for 'Name' failed on the 'required' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -202,7 +202,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q already exists", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -220,7 +220,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey: types.Metadata{Name: oneCappName, Namespace: namespaceName},
 				testutils.LabelsKey:   []types.KeyValue{{Key: oneLabelKey, Value: oneLabelValue + "-updated"}},
@@ -244,7 +244,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -262,7 +262,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -278,7 +278,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 	Context("Validate delete Capp route", func() {
 		It("Should delete Capp from namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CappsKey, oneCappName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MessageKey: fmt.Sprintf("Deleted capp %q in namespace %q successfully", oneCappName, namespaceName),
@@ -295,7 +295,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 		It("Should handle deletion of not found Capp", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CappsKey, oneCappName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
@@ -310,7 +310,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 		It("Should handle deletion of Capp in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.CappsKey, oneCappName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName),

--- a/test/e2e_tests/capprevision.go
+++ b/test/e2e_tests/capprevision.go
@@ -32,7 +32,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 	Context("Validate get CappRevisions route", func() {
 		It("Should get all CappRevisions in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CapprevisionsKey: append(oneCappRevisionNames, secondCappRevisionNames...),
@@ -48,7 +48,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", testutils.LabelCappName, secondCappName))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CapprevisionsKey: secondCappRevisionNames,
@@ -64,7 +64,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", testutils.LabelCappName, testutils.InvalidLabelSelector))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("unable to parse requirement: values[0][%s]: Invalid value: %q: "+
@@ -84,7 +84,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			params := url.Values{}
 			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s%s", testutils.LabelCappName, secondCappName, testutils.NonExistentSuffix))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CapprevisionsKey: nil,
@@ -99,7 +99,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 	Context("Validate get CappRevision route", func() {
 		It("Should get a specific CappRevision in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey, oneCappRevisionNames[0])
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey:    types.Metadata{Name: oneCappRevisionNames[0], Namespace: namespaceName},
@@ -115,7 +115,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 
 		It("Should handle a not found CappRevision in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey, oneCappName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CapprevisionsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
@@ -130,7 +130,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 
 		It("Should handle a get of a CappRevision in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.CapprevisionsKey, oneCappName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.CapprevisionsKey, cappv1alpha1.GroupVersion.Group, oneCappName),

--- a/test/e2e_tests/configmap.go
+++ b/test/e2e_tests/configmap.go
@@ -24,7 +24,7 @@ var _ = Describe("Validate ConfigMap routes and functionality", func() {
 	Context("Validate get ConfigMap route", func() {
 		It("Should get a specific ConfigMap in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.ConfigmapsKey, configMapName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DataKey: []types.KeyValue{{Key: testutils.ConfigMapDataKey, Value: testutils.ConfigMapDataValue}},
@@ -36,7 +36,7 @@ var _ = Describe("Validate ConfigMap routes and functionality", func() {
 
 		It("Should handle a not found ConfigMap in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.ConfigmapsKey, configMapName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.ConfigmapsKey, configMapName+testutils.NonExistentSuffix),
@@ -51,7 +51,7 @@ var _ = Describe("Validate ConfigMap routes and functionality", func() {
 
 		It("Should handle a get of a ConfigMap in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.ConfigmapsKey, configMapName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.ConfigmapsKey, configMapName),

--- a/test/e2e_tests/healthz.go
+++ b/test/e2e_tests/healthz.go
@@ -1,0 +1,23 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Validate Healthz route", func() {
+	It("Should return correct status code", func() {
+		uri := fmt.Sprintf("%s/healthz", platformURL)
+		status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+		expectedResponse := map[string]interface{}{
+			testutils.MessageKey: "ok",
+		}
+
+		Expect(status).Should(Equal(http.StatusOK))
+		compareResponses(response, expectedResponse)
+	})
+})

--- a/test/e2e_tests/helper.go
+++ b/test/e2e_tests/helper.go
@@ -65,7 +65,7 @@ func compareResponses(response, expectedResponse map[string]interface{}) {
 	Expect(response).Should(Equal(expectedResponseNormalized))
 }
 
-// prepareAuthorizedHTTPRequest prepares an authorized HTTP request.
+// prepareAuthorizedHTTPRequest prepares an HTTP request.
 // It creates a new HTTP request, sets the content type, and adds authorization headers as needed.
 func prepareAuthorizedHTTPRequest(body io.Reader, httpMethod, baseURI, username, password, userToken string) *http.Request {
 	request, err := http.NewRequest(httpMethod, baseURI, body)
@@ -87,8 +87,8 @@ func addAuthorization(request *http.Request, username, password, userToken strin
 	}
 }
 
-// performAuthorizedHTTPRequest makes an HTTP request and returns a response.
-func performAuthorizedHTTPRequest(httpClient http.Client, body io.Reader, httpMethod, baseURI, username, password, userToken string) (int, map[string]interface{}) {
+// performHTTPRequest makes an HTTP request and returns a response.
+func performHTTPRequest(httpClient http.Client, body io.Reader, httpMethod, baseURI, username, password, userToken string) (int, map[string]interface{}) {
 	request := prepareAuthorizedHTTPRequest(body, httpMethod, baseURI, username, password, userToken)
 
 	response, err := httpClient.Do(request)

--- a/test/e2e_tests/namespace.go
+++ b/test/e2e_tests/namespace.go
@@ -25,7 +25,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 	Context("Validate get Namespaces route", func() {
 		It("Should get namespaces", func() {
 			uri := fmt.Sprintf("%s/v1/%s", platformURL, testutils.NamespaceKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CountKey: 2,
@@ -48,7 +48,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 
 		It("Should not get namespaces without a Managed label", func() {
 			uri := fmt.Sprintf("%s/v1/%s", platformURL, testutils.NamespaceKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			Expect(status).Should(Equal(http.StatusOK))
 			Expect(testutils.KubeSystem).ToNot(BeElementOf(response[testutils.NamespaceKey]))
@@ -58,7 +58,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 	Context("Validate get Namespace route", func() {
 		It("Should get a specific namespace", func() {
 			uri := fmt.Sprintf("%s/v1/%s/%s", platformURL, testutils.NamespaceKey, oneNamespaceName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.NameKey: oneNamespaceName,
@@ -70,7 +70,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 
 		It("Should handle getting a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/%s/%s", platformURL, testutils.NamespaceKey, oneNamespaceName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.NamespaceKey, oneNamespaceName+testutils.NonExistentSuffix),
@@ -93,7 +93,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.NameKey: newNamespaceName,
 			}
@@ -115,7 +115,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'Namespace.Name' Error:Field validation for 'Name' failed on the 'required' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -131,7 +131,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q already exists", testutils.NamespaceKey, oneNamespaceName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -145,7 +145,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 	Context("Validate delete Namespace route", func() {
 		It("Should delete namespace", func() {
 			uri := fmt.Sprintf("%s/v1/%s/%s", platformURL, testutils.NamespaceKey, oneNamespaceName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MessageKey: fmt.Sprintf("Deleted namespace successfully %q", oneNamespaceName),
@@ -162,7 +162,7 @@ var _ = Describe("Validate Namespace routes and functionality", func() {
 
 		It("Should handle deletion of not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/%s/%s", platformURL, testutils.NamespaceKey, oneNamespaceName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.NamespaceKey, oneNamespaceName+testutils.NonExistentSuffix),

--- a/test/e2e_tests/secret.go
+++ b/test/e2e_tests/secret.go
@@ -32,7 +32,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate get Secrets route", func() {
 		It("Should get only secrets with a managed label in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.SecretsKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CountKey: 2,
@@ -58,7 +58,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate get Secret route", func() {
 		It("Should get a specific Secret in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.SecretsKey, oneSecretName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.SecretNameKey: oneSecretName,
@@ -81,7 +81,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle a not found Secret in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.SecretsKey, oneSecretName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName+testutils.NonExistentSuffix),
@@ -96,7 +96,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle a get of a ConfigMap in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.SecretsKey, oneSecretName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName),
@@ -119,7 +119,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.SecretNameKey:    newSecretName,
 				testutils.TypeKey:          corev1.SecretTypeOpaque,
@@ -146,7 +146,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'CreateSecretRequest.SecretName' Error:Field validation for 'SecretName' failed on the 'required' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -162,7 +162,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q already exists", testutils.SecretsKey, oneSecretName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -180,7 +180,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.SecretNameKey:    oneSecretName,
 				testutils.TypeKey:          corev1.SecretTypeOpaque,
@@ -204,7 +204,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName+testutils.NonExistentSuffix),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -220,7 +220,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -236,7 +236,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'UpdateSecretRequest.Data' Error:Field validation for 'Data' failed on the 'required' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -250,7 +250,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate delete Secret route", func() {
 		It("Should delete a Secret in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.SecretsKey, oneSecretName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MessageKey: fmt.Sprintf("Deleted secret %q in namespace %q successfully", oneSecretName, namespaceName),
@@ -267,7 +267,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle deletion of a not found Secret in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.SecretsKey, oneSecretName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName+testutils.NonExistentSuffix),
@@ -280,7 +280,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle deletion of a Secret in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.SecretsKey, oneSecretName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s %q not found", testutils.SecretsKey, oneSecretName),

--- a/test/e2e_tests/suite_test.go
+++ b/test/e2e_tests/suite_test.go
@@ -172,7 +172,7 @@ func getTokenFromLogin() {
 	userToken = ""
 
 	Eventually(func() bool {
-		_, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodPost, baseURI, e2eUser, e2ePassword, "")
+		_, response := performHTTPRequest(httpClient, nil, http.MethodPost, baseURI, e2eUser, e2ePassword, "")
 		token, ok := response[tokenKey]
 
 		if !ok {

--- a/test/e2e_tests/user.go
+++ b/test/e2e_tests/user.go
@@ -28,7 +28,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate get Users route", func() {
 		It("Should get users with a managed label in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.UsersKey)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CountKey: 2,
@@ -52,7 +52,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate get User route", func() {
 		It("Should get an existing User in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.UsersKey, oneUserName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.NameKey: oneUserName,
@@ -65,7 +65,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle getting a not found User in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.UsersKey, oneUserName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName+testutils.NonExistentSuffix),
@@ -80,7 +80,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle getting a User in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.UsersKey, oneUserName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName),
@@ -103,7 +103,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.NameKey: newUserName,
 				testutils.RoleKey: testutils.ViewerKey,
@@ -129,7 +129,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q already exists", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -145,7 +145,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPost, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'User.Role' Error:Field validation for 'Role' failed on the 'oneof' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -163,7 +163,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.NameKey: oneUserName,
 				testutils.RoleKey: testutils.ViewerKey,
@@ -184,7 +184,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName+testutils.NonExistentSuffix),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -200,7 +200,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName),
 				testutils.ErrorKey:   testutils.OperationFailed,
@@ -216,7 +216,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			payload, err := json.Marshal(requestData)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			status, response := performAuthorizedHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, bytes.NewBuffer(payload), http.MethodPut, uri, "", "", userToken)
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: "Key: 'UpdateUserData.Role' Error:Field validation for 'Role' failed on the 'oneof' tag",
 				testutils.ErrorKey:   testutils.InvalidRequest,
@@ -230,7 +230,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 	Context("Validate delete User route", func() {
 		It("Should delete a User in an existing namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.UsersKey, oneUserName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.MessageKey: fmt.Sprintf("Deleted roleBinding %q in namespace %q successfully", oneUserName, namespaceName),
@@ -247,7 +247,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle deletion of a not found User in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.UsersKey, oneUserName+testutils.NonExistentSuffix)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName+testutils.NonExistentSuffix),
@@ -260,7 +260,7 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 
 		It("Should handle deletion of a User in a not found namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.UsersKey, oneUserName)
-			status, response := performAuthorizedHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.DetailsKey: fmt.Sprintf("%s.%s %q not found", testutils.RoleBindingsKey, testutils.RoleBindingsGroupKey, oneUserName),


### PR DESCRIPTION
This PR uses an existing route to create a liveness probe for the platform deployment on Capp, and also configures a readiness probe.