### PR TITLE
feat: implement server side pagination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ NAMESPACE ?= platform-backend-system
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
 CONTAINER_TOOL ?= docker
+platformUrl ?=
 
 ##@ Development
 
@@ -28,7 +29,7 @@ test-e2e: ginkgo
 	@test -n "${KUBECONFIG}" -o -r ${HOME}/.kube/config || (echo "Failed to find kubeconfig in ~/.kube/config or no KUBECONFIG set"; exit 1)
 	echo "Running e2e tests"
 	go clean -testcache
-	$(LOCALBIN)/ginkgo -p --vv ./test/e2e_tests/... -coverprofile cover.out -timeout
+	$(LOCALBIN)/ginkgo -p --vv ./test/e2e_tests/... -coverprofile cover.out -timeout -- -platformUrl=$(platformUrl)
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint

--- a/README.md
+++ b/README.md
@@ -105,3 +105,26 @@ $ curl -H "Authorization: Bearer <TOKEN_VALUE>" \
   "count": 2
 }
 ```
+
+## Testing
+To ensure your backend is working correctly, you can run end-to-end (e2e) tests.
+
+### Running End-to-End Tests
+To run e2e tests, use the test-e2e target defined in the Makefile. You can pass the platformUrl flag to specify the URL of the platform backend.
+
+1. Run Tests with Specific Platform URL:
+    ```bash
+    make test-e2e platformUrl=<your-platform-url>
+    ```
+    Replace <your-platform-url> with the actual URL of the platform backend.
+    Example:
+    If your platform URL is http://localhost:8080, you would run:
+    ```bash
+    make test-e2e platformUrl=http://localhost:8080
+    ```
+2. Run Tests with Default URL:
+   ```bash
+   make test-e2e
+   ```
+   If you leave the platformUrl flag empty, the tests will automatically use the default URL of the backend deployed in OpenShift. 
+

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
   KUBE_USERINFO_URL: "https://api.{{ .Values.clusterName }}.{{ .Values.clusterDomain }}:{{ .Values.apiPort }}/apis/user.openshift.io/v1/users/~"
   KUBE_API_SERVER: "https://api.{{ .Values.clusterName }}.{{ .Values.clusterDomain }}:{{ .Values.apiPort }}"
   ALLOWED_ORIGIN_REGEX: "{{ .Values.allowedOriginRegex }}"
+  DEFAULT_PAGINATION_LIMIT: "{{ .Values.defaultPaginationLimit }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,3 +63,6 @@ livenessProbe:
   port: 8080
   initialDelaySeconds: 5
   periodSeconds: 10
+
+# -- Default pagination limit
+defaultPaginationLimit: 100

--- a/docs/api/capp.md
+++ b/docs/api/capp.md
@@ -11,9 +11,8 @@ This document outlines the CRUD (Create, Read, Update, Delete) on Capp.
   - **Path Parameter**:
     - `namespace` - The namespace of the capp.
   - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
-    - `labelSelector`: (optional) Used for filtering by labels.
+    - `limit`: (optional) Specifies the maximum number of namespaces to return per page.
+    - `page`: (optional) Used for setting the current pge.
   - **Response**: Capp names or an error message.
     ```json
     {

--- a/docs/api/capp_revision.md
+++ b/docs/api/capp_revision.md
@@ -9,9 +9,8 @@ This document outlines the CRUD (Create, Read, Update, Delete) on CappRevision. 
 - **GET** `/v1/namespaces/{namespace}/cappRevisions`
   - **Description**: Get all cappRevision of namespace.
   - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
-    - `labelSelector`: (optional) Used for filtering by labels.
+    - `limit`: (optional) Specifies the maximum number of namespaces to return per page.
+    - `page`: (optional) Used for setting the current pge.
   - **Response**: CappRevision names or an error message.
     ```json
     {

--- a/docs/api/containers.md
+++ b/docs/api/containers.md
@@ -30,10 +30,6 @@ This API allowes retrieving the containers within a specified pod in a given nam
   - **Path Parameter**:
     - `namespace` - The namespace of the pod.
     - `podName` -  The name of the pod whose containers are being listed.
-  - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of containers to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
-    - `labelSelector`: (optional) Used for filtering by labels.
   - **Response**: A JSON object containing the list of containers within the specified pod or an error message if the request fails.
     ```json
     {

--- a/docs/api/namespace.md
+++ b/docs/api/namespace.md
@@ -11,9 +11,8 @@ This document outlines the CRUD (Create, Read, Update, Delete) operations for ma
   - **Path Parameter**:
     - `namespace` - The namespace of the capp.
   - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
-    - `labels`: (optional) Used for filtering namespaces by labels.
+    - `limit`: (optional) Specifies the maximum number of namespaces to return per page.
+    - `page`: (optional) Used for setting the current pge.
   - **Response**: Namespaces names or an error message.
     ```json
     {

--- a/docs/api/secrets.md
+++ b/docs/api/secrets.md
@@ -49,8 +49,8 @@ This document outlines the CRUD (Create, Read, Update, Delete) operations for ma
   - **Description**: Retrieve details of a specific secret, TLS, or opaque.
   - **Path Parameter**: `namespace` - The namespace of the secrets.
   - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
+    - `limit`: (optional) Specifies the maximum number of namespaces to return per page.
+    - `page`: (optional) Used for setting the current pge.
   - **Response**: Returns the secret details or an error message if not found.
     ```json
     {

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -11,8 +11,8 @@ This document outlines the CRUD (Create, Read, Update, Delete) operations for ma
   - **Path Parameter**: 
     - `namespace` - Namespace of the capp.
   - **Query Params**:
-    - `limit`: (optional) Specifies the maximum number of namespaces to return per page. Defaults to 9.
-    - `continue`: (optional) Used for fetching the next set of results.
+    - `limit`: (optional) Specifies the maximum number of namespaces to return per page.
+    - `page`: (optional) Used for setting the current pge.
   - **Response**: User of the namespace or an error message.
     ```json
     {

--- a/src/controllers/containers_test.go
+++ b/src/controllers/containers_test.go
@@ -32,7 +32,7 @@ func TestGetContainers(t *testing.T) {
 			},
 			want: want{
 				response: types.GetContainersResponse{
-					Count: 2,
+					ListMetadata: types.ListMetadata{Count: 2},
 					Containers: []types.Container{
 						{ContainerName: testutils.TestContainerName},
 						{ContainerName: testutils.CappName},

--- a/src/controllers/logs.go
+++ b/src/controllers/logs.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 	"io"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/dana-team/platform-backend/src/utils"
 	"k8s.io/client-go/kubernetes"
@@ -26,7 +27,7 @@ func FetchPodLogs(ctx context.Context, client kubernetes.Interface, namespace, p
 // FetchCappLogs retrieves the logs of a Capp's Knative service.
 // It fetches the pods associated with the service, selects the first pod, and retrieves its logs.
 func FetchCappLogs(ctx context.Context, client kubernetes.Interface, namespace, cappName, containerName, podName string, logger *zap.Logger) (io.ReadCloser, error) {
-	pods, err := utils.GetPodsByLabel(ctx, client, namespace, fmt.Sprintf(utils.ParentCappLabelSelector, cappName))
+	pods, err := utils.GetPodsByLabel(ctx, client, namespace, fmt.Sprintf(utils.ParentCappLabelSelector, cappName), metav1.ListOptions{})
 	if err != nil {
 		logger.Error(fmt.Sprintf("error fetching Capp pods: %s", err.Error()))
 		return nil, fmt.Errorf("error fetching Capp pods: %w", err)

--- a/src/controllers/pods_test.go
+++ b/src/controllers/pods_test.go
@@ -1,9 +1,9 @@
 package controllers
 
 import (
-	"context"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +15,8 @@ func TestGetPods(t *testing.T) {
 	type args struct {
 		namespace string
 		cappName  string
+		limit     int
+		page      int
 	}
 	type want struct {
 		response types.GetPodsResponse
@@ -31,7 +33,7 @@ func TestGetPods(t *testing.T) {
 			},
 			want: want{
 				response: types.GetPodsResponse{
-					Count: 2,
+					ListMetadata: types.ListMetadata{Count: 2},
 					Pods: []types.Pod{
 						{PodName: pod1},
 						{PodName: pod2},
@@ -51,14 +53,18 @@ func TestGetPods(t *testing.T) {
 	}
 
 	setup()
-	podController := NewPodController(fakeClient, context.TODO(), logger)
 	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
 	mocks.CreateTestPod(fakeClient, namespaceName, pod1, testutils.CappName, false)
 	mocks.CreateTestPod(fakeClient, namespaceName, pod2, testutils.CappName, true)
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			response, err := podController.GetPods(test.args.namespace, test.args.cappName)
+			c := mocks.GinContext()
+			mocks.SetPaginationValues(c, test.args.limit, test.args.page)
+			podController := NewPodController(fakeClient, c, logger)
+
+			limit, page, _ := pagination.ExtractPaginationParamsFromCtx(c)
+			response, err := podController.GetPods(test.args.namespace, test.args.cappName, limit, page)
 			if test.want.error != "" {
 				assert.ErrorContains(t, err, test.want.error)
 			} else {

--- a/src/middleware/pagination_middleware.go
+++ b/src/middleware/pagination_middleware.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+const (
+	PageCtxKey  = "page"
+	LimitCtxKey = "limit"
+)
+
+// PaginationMiddleware is a middleware for extracting and setting pagination parameters from the request context
+func PaginationMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctxLogger, exists := c.Get(LoggerCtxKey)
+		if !exists {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "logger not set in context"})
+			return
+		}
+		logger := ctxLogger.(*zap.Logger)
+
+		logger.Info("setting up pagination middleware")
+
+		var paginationParams types.PaginationParams
+		if err := c.BindQuery(&paginationParams); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
+		c.Set(LimitCtxKey, paginationParams.Limit)
+		c.Set(PageCtxKey, paginationParams.Page)
+		c.Next()
+	}
+}

--- a/src/middleware/pagination_middleware_test.go
+++ b/src/middleware/pagination_middleware_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+)
+
+func Test_PaginationMiddleware(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	router := gin.New()
+
+	// Set up a middleware that injects the logger into the context
+	router.Use(func(c *gin.Context) {
+		c.Set(LoggerCtxKey, logger)
+		c.Next()
+	})
+
+	router.Use(PaginationMiddleware()).GET("/ping", func(c *gin.Context) {
+		_, exists := c.Get(LimitCtxKey)
+		if !exists {
+			t.Error("Expected limit to be set in context")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "limit not set in context"})
+			return
+		}
+
+		_, exists = c.Get(PageCtxKey)
+		if !exists {
+			t.Error("Expected page to be set in context")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "page not set in context"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"message": "pong",
+		})
+	})
+
+	type args struct {
+		path string
+	}
+	type want struct {
+		expectedStatus int
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldSuccess": {
+			args: args{
+				path: "/ping",
+			},
+			want: want{
+				expectedStatus: http.StatusOK,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.args.path, nil)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tc.want.expectedStatus {
+				t.Errorf("Expected status code %d; got %d", tc.want.expectedStatus, w.Code)
+			}
+		})
+	}
+}

--- a/src/routes/v1/capp.go
+++ b/src/routes/v1/capp.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
 	"github.com/dana-team/platform-backend/src/controllers"
@@ -47,14 +48,21 @@ func GetCapps() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
 			return
 		}
+
 		var cappQuery types.CappQuery
 		if err := c.BindQuery(&cappQuery); err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
 			return
 		}
 
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
 		cappHandler(func(controller controllers.CappController, c *gin.Context) (interface{}, error) {
-			return controller.GetCapps(cappUri.NamespaceName, cappQuery)
+			return controller.GetCapps(cappUri.NamespaceName, limit, page, cappQuery)
 		})(c)
 	}
 }

--- a/src/routes/v1/capprevision.go
+++ b/src/routes/v1/capprevision.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
 	"github.com/dana-team/platform-backend/src/controllers"
@@ -47,14 +48,21 @@ func GetCappRevisions() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
 			return
 		}
+
 		var cappRevisionQuery types.CappRevisionQuery
 		if err := c.BindQuery(&cappRevisionQuery); err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
 			return
 		}
 
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
 		cappRevisionHandler(func(controller controllers.CappRevisionController, c *gin.Context) (interface{}, error) {
-			return controller.GetCappRevisions(cappRevisionUri.NamespaceName, cappRevisionQuery)
+			return controller.GetCappRevisions(cappRevisionUri.NamespaceName, limit, page, cappRevisionQuery)
 		})(c)
 	}
 }

--- a/src/routes/v1/namespace.go
+++ b/src/routes/v1/namespace.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -44,9 +45,17 @@ func namespaceHandler(handler func(controller controllers.NamespaceController, c
 }
 
 func GetNamespaces() gin.HandlerFunc {
-	return namespaceHandler(func(controller controllers.NamespaceController, c *gin.Context) (interface{}, error) {
-		return controller.GetNamespaces()
-	})
+	return func(c *gin.Context) {
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
+		namespaceHandler(func(controller controllers.NamespaceController, c *gin.Context) (interface{}, error) {
+			return controller.GetNamespaces(limit, page)
+		})(c)
+	}
 }
 
 func GetNamespace() gin.HandlerFunc {

--- a/src/routes/v1/pods.go
+++ b/src/routes/v1/pods.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dana-team/platform-backend/src/controllers"
 	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,8 +51,14 @@ func GetPods() gin.HandlerFunc {
 			return
 		}
 
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
 		podHandler(func(controller controllers.PodController, c *gin.Context) (interface{}, error) {
-			return controller.GetPods(request.NamespaceName, request.CappName)
+			return controller.GetPods(request.NamespaceName, request.CappName, limit, page)
 		})(c)
 	}
 }

--- a/src/routes/v1/pods_test.go
+++ b/src/routes/v1/pods_test.go
@@ -3,10 +3,12 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,12 +18,18 @@ const (
 	podNamespace = testutils.TestNamespace + testutils.PodsKey
 )
 
-func TestGetPod(t *testing.T) {
+func TestGetPods(t *testing.T) {
 	testNamespaceName := podNamespace + "-get"
 
+	type pagination struct {
+		limit string
+		page  string
+	}
+
 	type args struct {
-		cappName  string
-		namespace string
+		cappName         string
+		namespace        string
+		paginationParams pagination
 	}
 
 	type want struct {
@@ -37,6 +45,23 @@ func TestGetPod(t *testing.T) {
 			args: args{
 				namespace: testNamespaceName,
 				cappName:  testutils.CappName,
+			},
+			want: want{
+				statusCode: http.StatusOK,
+				response: map[string]interface{}{
+					testutils.PodsKey: []interface{}{
+						map[string]interface{}{testutils.PodNameKey: pod1},
+						map[string]interface{}{testutils.PodNameKey: pod2},
+					},
+					testutils.CountKey: 2,
+				},
+			},
+		},
+		"ShouldSucceedGettingAllPodsWithLimitOf2": {
+			args: args{
+				namespace:        testNamespaceName,
+				cappName:         testutils.CappName,
+				paginationParams: pagination{limit: "2", page: "1"},
 			},
 			want: want{
 				statusCode: http.StatusOK,
@@ -85,8 +110,17 @@ func TestGetPod(t *testing.T) {
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
+			params := url.Values{}
+			if test.args.paginationParams.limit != "" {
+				params.Add(middleware.LimitCtxKey, test.args.paginationParams.limit)
+			}
+
+			if test.args.paginationParams.page != "" {
+				params.Add(middleware.PageCtxKey, test.args.paginationParams.page)
+			}
+
 			baseURI := fmt.Sprintf("/v1/namespaces/%s/capps/%s/pods", test.args.namespace, test.args.cappName)
-			request, err := http.NewRequest(http.MethodGet, baseURI, nil)
+			request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s?%s", baseURI, params.Encode()), nil)
 			assert.NoError(t, err)
 			writer := httptest.NewRecorder()
 			router.ServeHTTP(writer, request)

--- a/src/routes/v1/secret.go
+++ b/src/routes/v1/secret.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
 	"github.com/dana-team/platform-backend/src/controllers"
@@ -70,8 +71,14 @@ func GetSecrets() gin.HandlerFunc {
 			return
 		}
 
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
 		secretHandler(func(controller controllers.SecretController, c *gin.Context) (interface{}, error) {
-			return controller.GetSecrets(request.NamespaceName)
+			return controller.GetSecrets(request.NamespaceName, limit, page)
 		})(c)
 	}
 }

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -32,7 +32,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	namespacesGroup := v1.Group("/namespaces")
 	namespacesGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
-		namespacesGroup.GET("", GetNamespaces())
+		namespacesGroup.Use(middleware.PaginationMiddleware()).GET("", GetNamespaces())
 		namespacesGroup.GET("/:namespaceName", GetNamespace())
 		namespacesGroup.POST("", CreateNamespace())
 		namespacesGroup.DELETE("/:namespaceName", DeleteNamespace())
@@ -42,7 +42,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	secretsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		secretsGroup.POST("", CreateSecret())
-		secretsGroup.GET("", GetSecrets())
+		secretsGroup.Use(middleware.PaginationMiddleware()).GET("", GetSecrets())
 		secretsGroup.GET("/:secretName", GetSecret())
 		secretsGroup.PUT("/:secretName", UpdateSecret())
 		secretsGroup.DELETE("/:secretName", DeleteSecret())
@@ -52,7 +52,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	cappGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		cappGroup.POST("", CreateCapp())
-		cappGroup.GET("", GetCapps())
+		cappGroup.Use(middleware.PaginationMiddleware()).GET("", GetCapps())
 		cappGroup.GET("/:cappName", GetCapp())
 		cappGroup.PUT("/:cappName", UpdateCapp())
 		cappGroup.PUT("/:cappName/state", EditCappState())
@@ -63,7 +63,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capprevisions")
 	cappRevisionGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
-		cappRevisionGroup.GET("", GetCappRevisions())
+		cappRevisionGroup.Use(middleware.PaginationMiddleware()).GET("", GetCappRevisions())
 		cappRevisionGroup.GET("/:cappRevisionName", GetCappRevision())
 	}
 
@@ -71,7 +71,7 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	usersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		usersGroup.POST("", CreateUser())
-		usersGroup.GET("", GetUsers())
+		usersGroup.Use(middleware.PaginationMiddleware()).GET("", GetUsers())
 		usersGroup.GET("/:userName", GetUser())
 		usersGroup.PUT("/:userName", UpdateUser())
 		usersGroup.DELETE("/:userName", DeleteUser())
@@ -92,6 +92,6 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	podsGroup := namespacesGroup.Group("/:namespaceName")
 	podsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
-		podsGroup.GET("/capps/:cappName/pods", GetPods())
+		podsGroup.Use(middleware.PaginationMiddleware()).GET("/capps/:cappName/pods", GetPods())
 	}
 }

--- a/src/routes/v1/setup_test.go
+++ b/src/routes/v1/setup_test.go
@@ -45,7 +45,7 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 	{
 		namespacesGroup := v1.Group("/namespaces")
 		{
-			namespacesGroup.GET("", GetNamespaces())
+			namespacesGroup.Use(middleware.PaginationMiddleware()).GET("", GetNamespaces())
 			namespacesGroup.GET("/:namespaceName", GetNamespace())
 			namespacesGroup.POST("", CreateNamespace())
 			namespacesGroup.DELETE("/:namespaceName", DeleteNamespace())
@@ -53,7 +53,7 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 			secretsGroup := namespacesGroup.Group("/:namespaceName/secrets")
 			{
 				secretsGroup.POST("", CreateSecret())
-				secretsGroup.GET("", GetSecrets())
+				secretsGroup.Use(middleware.PaginationMiddleware()).GET("", GetSecrets())
 				secretsGroup.GET("/:secretName", GetSecret())
 				secretsGroup.PUT("/:secretName", UpdateSecret())
 				secretsGroup.DELETE("/:secretName", DeleteSecret())
@@ -63,7 +63,7 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 			{
 
 				cappGroup.POST("", CreateCapp())
-				cappGroup.GET("", GetCapps())
+				cappGroup.Use(middleware.PaginationMiddleware()).GET("", GetCapps())
 				cappGroup.GET("/:cappName", GetCapp())
 				cappGroup.PUT("/:cappName", UpdateCapp())
 				cappGroup.PUT("/:cappName/state", EditCappState())
@@ -75,14 +75,14 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 			cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capprevisions")
 			{
 
-				cappRevisionGroup.GET("", GetCappRevisions())
+				cappRevisionGroup.Use(middleware.PaginationMiddleware()).GET("", GetCappRevisions())
 				cappRevisionGroup.GET("/:cappRevisionName", GetCappRevision())
 			}
 
 			usersGroup := namespacesGroup.Group("/:namespaceName/users")
 			{
 				usersGroup.POST("", CreateUser())
-				usersGroup.GET("", GetUsers())
+				usersGroup.Use(middleware.PaginationMiddleware()).GET("", GetUsers())
 				usersGroup.GET("/:userName", GetUser())
 				usersGroup.PUT("/:userName", UpdateUser())
 				usersGroup.DELETE("/:userName", DeleteUser())
@@ -106,7 +106,7 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 
 			podsGroup := namespacesGroup.Group("/:namespaceName")
 			{
-				podsGroup.GET("/capps/:cappName/pods", GetPods())
+				podsGroup.Use(middleware.PaginationMiddleware()).GET("/capps/:cappName/pods", GetPods())
 			}
 		}
 	}

--- a/src/routes/v1/users.go
+++ b/src/routes/v1/users.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"github.com/dana-team/platform-backend/src/controllers"
 	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -91,8 +92,14 @@ func GetUsers() gin.HandlerFunc {
 			return
 		}
 
+		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "details": err.Error()})
+			return
+		}
+
 		usersHandler(func(controller controllers.UserController, c *gin.Context) (interface{}, error) {
-			return controller.GetUsers(namespace.NamespaceName)
+			return controller.GetUsers(namespace.NamespaceName, limit, page)
 		})(c)
 	}
 }

--- a/src/types/capp.go
+++ b/src/types/capp.go
@@ -35,7 +35,7 @@ type CappQuery struct {
 
 type CappList struct {
 	Capps []CappSummary `json:"capps"`
-	Count int           `json:"count"`
+	ListMetadata
 }
 
 type CappSummary struct {

--- a/src/types/capprevision.go
+++ b/src/types/capprevision.go
@@ -14,7 +14,7 @@ type CappRevision struct {
 
 type CappRevisionList struct {
 	CappRevisions []string `json:"capprevisions"`
-	Count         int      `json:"count"`
+	ListMetadata
 }
 
 type CappRevisionNamespaceUri struct {

--- a/src/types/common.go
+++ b/src/types/common.go
@@ -10,3 +10,7 @@ type Metadata struct {
 	Namespace         string `json:"namespace"`
 	CreationTimestamp string `json:"creationTimestamp"`
 }
+
+type ListMetadata struct {
+	Count int `json:"count"`
+}

--- a/src/types/containers.go
+++ b/src/types/containers.go
@@ -1,8 +1,8 @@
 package types
 
 type GetContainersResponse struct {
-	Count      int         `json:"count"`
 	Containers []Container `json:"containers"`
+	ListMetadata
 }
 
 type Container struct {

--- a/src/types/namespace.go
+++ b/src/types/namespace.go
@@ -6,7 +6,7 @@ type Namespace struct {
 
 type NamespaceList struct {
 	Namespaces []Namespace `json:"namespaces"`
-	Count      int         `json:"count"`
+	ListMetadata
 }
 
 type NamespaceUri struct {

--- a/src/types/pagination.go
+++ b/src/types/pagination.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type List[T any] struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard list metadata.
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Items is a list of objects.
+	Items []T `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+type PaginationParams struct {
+	Limit int `form:"limit,omitempty" binding:"min=0"`
+	Page  int `form:"page,default=1,omitempty" binding:"min=1"`
+}

--- a/src/types/pods.go
+++ b/src/types/pods.go
@@ -1,8 +1,8 @@
 package types
 
 type GetPodsResponse struct {
-	Count int   `json:"count"`
-	Pods  []Pod `json:"pods"`
+	Pods []Pod `json:"pods"`
+	ListMetadata
 }
 
 type Pod struct {

--- a/src/types/secret.go
+++ b/src/types/secret.go
@@ -24,8 +24,8 @@ type SecretNamespaceUriRequest struct {
 }
 
 type GetSecretsResponse struct {
-	Count   int      `json:"count"`
 	Secrets []Secret `json:"secrets"`
+	ListMetadata
 }
 
 type GetSecretResponse struct {

--- a/src/types/user.go
+++ b/src/types/user.go
@@ -21,7 +21,7 @@ type UpdateUserData struct {
 
 type UsersOutput struct {
 	Users []User `json:"users"`
-	Count int    `json:"count"`
+	ListMetadata
 }
 
 type DeleteUserResponse struct {

--- a/src/utils/env.go
+++ b/src/utils/env.go
@@ -21,3 +21,19 @@ func GetEnvBool(key string, defaultValue bool) (bool, error) {
 
 	return valBool, nil
 }
+
+// GetEnvNumber retrieves the value of the environment variable named by the key.
+// If the variable is empty or not set, it returns the default value.
+func GetEnvNumber(key string, defaultValue int) (int, error) {
+	valStr := os.Getenv(key)
+	if valStr == "" {
+		return defaultValue, nil
+	}
+
+	valInt, err := strconv.Atoi(valStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse %q as integer", valStr)
+	}
+
+	return valInt, nil
+}

--- a/src/utils/pagination/pagination.go
+++ b/src/utils/pagination/pagination.go
@@ -1,0 +1,91 @@
+package pagination
+
+import (
+	"fmt"
+	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/gin-gonic/gin"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	envDefaultPaginationLimit = "DEFAULT_PAGINATION_LIMIT"
+	defaultPaginationLimit    = 100
+
+	firstPage = 1
+)
+
+// buildListOptions builds the ListOptions based on page and limit
+func buildListOptions(limit int64, continueToken string) v1.ListOptions {
+	return v1.ListOptions{
+		Limit:         limit,
+		Continue:      continueToken,
+		LabelSelector: utils.ManagedLabelSelector,
+	}
+}
+
+// FetchPage fetches the specified page with given limit
+func FetchPage[T any](limit, page int, paginator Paginator[types.List[T]]) ([]T, error) {
+	var results []T
+	var continueToken string
+
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be greater than zero")
+	}
+
+	// Fetch items until the specified page is reached
+	for currentPage := firstPage; currentPage <= page; currentPage++ {
+		listOptions := buildListOptions(int64(limit), continueToken)
+		list, err := paginator.FetchList(listOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		if currentPage == page {
+			return list.Items, nil
+		}
+
+		continueToken = list.Continue
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+// extractLimitFromCtx retrieves the pagination limit from the Gin context or defaults to an environment variable
+func extractLimitFromCtx(c *gin.Context) (int, error) {
+	limit, exists := c.Get(middleware.LimitCtxKey)
+	if !exists || limit == 0 {
+		return utils.GetEnvNumber(envDefaultPaginationLimit, defaultPaginationLimit)
+	}
+
+	return limit.(int), nil
+}
+
+// extractPageFromCtx retrieves the page number from the context; returns 1 if not set or an error if conversion fails
+func extractPageFromCtx(c *gin.Context) (int, error) {
+	page, exists := c.Get(middleware.PageCtxKey)
+	if !exists || page == 0 {
+		return firstPage, nil
+	}
+
+	return page.(int), nil
+}
+
+// ExtractPaginationParamsFromCtx retrieves the page and limit from the context
+func ExtractPaginationParamsFromCtx(c *gin.Context) (limit, page int, err error) {
+	ctxLimit, err := extractLimitFromCtx(c)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	ctxPage, err := extractPageFromCtx(c)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return ctxLimit, ctxPage, nil
+}

--- a/src/utils/pagination/pagination_test.go
+++ b/src/utils/pagination/pagination_test.go
@@ -1,0 +1,280 @@
+package pagination
+
+import (
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	strForPagination = "string-for-pagination"
+)
+
+type TestPaginator struct {
+	str string
+}
+
+func (p *TestPaginator) FetchList(listOptions metav1.ListOptions) (*types.List[string], error) {
+	limit := listOptions.Limit
+	startIndex := 0
+
+	items := []string{
+		p.str + "-1",
+		p.str + "-2",
+		p.str + "-3",
+		p.str + "-4",
+		p.str + "-5",
+	}
+
+	endIndex := startIndex + int(limit)
+	if endIndex > len(items) {
+		endIndex = len(items)
+	}
+
+	return &types.List[string]{
+		Items: items[startIndex:endIndex],
+	}, nil
+}
+
+func Test_buildListOptions(t *testing.T) {
+	type args struct {
+		limit         int64
+		continueToken string
+	}
+
+	type want struct {
+		listOptions metav1.ListOptions
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldBuildListOptions": {
+			args: args{
+				limit:         int64(20),
+				continueToken: "token",
+			},
+			want: want{
+				listOptions: metav1.ListOptions{
+					Limit:         int64(20),
+					Continue:      "token",
+					LabelSelector: utils.ManagedLabelSelector,
+				},
+			},
+		},
+		"ShouldBuildEmptyListOptions": {
+			args: args{
+				limit:         0,
+				continueToken: "",
+			},
+			want: want{
+				listOptions: metav1.ListOptions{
+					Limit:         0,
+					Continue:      "",
+					LabelSelector: utils.ManagedLabelSelector,
+				},
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			listOptions := buildListOptions(test.args.limit, test.args.continueToken)
+			assert.Equal(t, test.want.listOptions, listOptions)
+		})
+	}
+}
+
+func Test_FetchPage(t *testing.T) {
+	type args struct {
+		page      int
+		limit     int
+		paginator Paginator[types.List[string]]
+	}
+
+	type want struct {
+		strings []string
+		err     error
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldReturnOneStringOnFirstPage": {
+			args: args{
+				limit: 1,
+				page:  1,
+				paginator: &TestPaginator{
+					str: strForPagination,
+				},
+			},
+			want: want{
+				strings: []string{
+					strForPagination + "-1",
+				},
+				err: nil,
+			},
+		},
+		"ShouldReturnAllStrings": {
+			args: args{
+				limit: 5,
+				page:  1,
+				paginator: &TestPaginator{
+					str: strForPagination,
+				},
+			},
+			want: want{
+				strings: []string{
+					strForPagination + "-1",
+					strForPagination + "-2",
+					strForPagination + "-3",
+					strForPagination + "-4",
+					strForPagination + "-5",
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			stringsList, err := FetchPage(test.args.limit, test.args.page, test.args.paginator)
+			if test.want.err != nil {
+				assert.Equal(t, test.want.err, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.want.strings, stringsList)
+
+		})
+	}
+}
+
+func Test_extractLimitFromCtx(t *testing.T) {
+	const defaultPaginationLimitStr = "100"
+	const defaultPaginationLimitInt = 100
+
+	_ = os.Setenv(envDefaultPaginationLimit, defaultPaginationLimitStr)
+
+	type args struct {
+		limit int
+	}
+
+	type want struct {
+		limit int
+		err   error
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldReturnLimitFromCtx": {
+			args: args{
+				limit: 5,
+			},
+			want: want{
+				limit: 5,
+				err:   nil,
+			},
+		},
+		"ShouldReturnDefaultLimitFromCtx": {
+			want: want{
+				limit: defaultPaginationLimitInt,
+				err:   nil,
+			},
+		},
+
+		"ShouldReturnInvalidLimit": {
+			args: args{
+				limit: -1,
+			},
+			want: want{
+				limit: -1,
+				err:   nil,
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := mocks.GinContext()
+			mocks.SetPaginationValues(c, test.args.limit, 0)
+
+			limit, err := extractLimitFromCtx(c)
+			if test.want.err != nil {
+				assert.Equal(t, test.want.err.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.want.limit, limit)
+		})
+	}
+}
+
+func Test_extractPageFromCtx(t *testing.T) {
+	type args struct {
+		page int
+	}
+
+	type want struct {
+		page int
+		err  error
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldReturnPage": {
+			args: args{
+				page: 5,
+			},
+			want: want{
+				page: 5,
+				err:  nil,
+			},
+		},
+		"ShouldReturnDefaultPage": {
+			want: want{
+				page: 1,
+				err:  nil,
+			},
+		},
+
+		"ShouldReturnInvalidLimit": {
+			args: args{
+				page: -1,
+			},
+			want: want{
+				page: -1,
+				err:  nil,
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := mocks.GinContext()
+			mocks.SetPaginationValues(c, 0, test.args.page)
+
+			page, err := extractPageFromCtx(c)
+			if test.want.err != nil {
+				assert.Equal(t, test.want.err.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.want.page, page)
+		})
+	}
+}

--- a/src/utils/pagination/paginator.go
+++ b/src/utils/pagination/paginator.go
@@ -1,0 +1,33 @@
+package pagination
+
+import (
+	"context"
+	"fmt"
+	"github.com/dana-team/platform-backend/src/types"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Paginator interface with methods for pagination
+type Paginator[T any] interface {
+	FetchList(listOptions metav1.ListOptions) (*T, error)
+}
+
+// GenericPaginator to handle any Kubernetes list type
+type GenericPaginator struct {
+	Ctx    context.Context
+	Logger *zap.Logger
+}
+
+// FetchList fetches the list of resources of any type
+func (p *GenericPaginator) FetchList(listOptions metav1.ListOptions) (*types.List[interface{}], error) {
+	// This method needs to be adapted based on the type of resource
+	return nil, fmt.Errorf("FetchList method not implemented")
+}
+
+func CreatePaginator(ctx context.Context, logger *zap.Logger) GenericPaginator {
+	return GenericPaginator{
+		Ctx:    ctx,
+		Logger: logger,
+	}
+}

--- a/src/utils/parse.go
+++ b/src/utils/parse.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"strconv"
+)
+
+// ParseIntStr parses a string into an int64 number.
+func ParseIntStr(intStr string) (int64, error) {
+	number, err := strconv.ParseInt(intStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return number, nil
+}

--- a/src/utils/pods.go
+++ b/src/utils/pods.go
@@ -14,10 +14,9 @@ var (
 )
 
 // GetPodsByLabel returns the pods in a namespace using a given label selector.
-func GetPodsByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string) (*corev1.PodList, error) {
-	return client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+func GetPodsByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string, listOptions metav1.ListOptions) (*corev1.PodList, error) {
+	listOptions.LabelSelector = labelSelector
+	return client.CoreV1().Pods(namespace).List(ctx, listOptions)
 }
 
 // GetPodLogStream returns the logs of a container in a pod.

--- a/src/utils/testutils/mocks/gin.go
+++ b/src/utils/testutils/mocks/gin.go
@@ -1,0 +1,20 @@
+package mocks
+
+import (
+	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"net/http/httptest"
+)
+
+// GinContext creates a new *gin.Context for testing purposes
+func GinContext() *gin.Context {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = &http.Request{}
+	return c
+}
+
+func SetPaginationValues(c *gin.Context, limit, page int) {
+	c.Set(middleware.LimitCtxKey, limit)
+	c.Set(middleware.PageCtxKey, page)
+}

--- a/test/e2e_tests/capp.go
+++ b/test/e2e_tests/capp.go
@@ -50,6 +50,77 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			compareResponses(response, expectedResponse)
 		})
 
+		It("Should get all Capps in a namespace with limit of 50", func() {
+			limit := "50"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CappsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CappsKey: []types.CappSummary{
+					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, clusterDomain)},
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+				},
+				testutils.CountKey: 2,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one Capp in a namespace with limit of 1 and page 1", func() {
+			limit := "1"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CappsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CappsKey: []types.CappSummary{
+					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, clusterDomain)},
+				},
+				testutils.CountKey: 1,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one Capp in a namespace with limit of 1 and page 2", func() {
+			limit := "1"
+			page := "2"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CappsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CappsKey: []types.CappSummary{
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+				},
+				testutils.CountKey: 1,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should not get Capps with limit of 1 and page 3", func() {
+			limit := "1"
+			page := "3"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CappsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CappsKey: nil,
+				testutils.CountKey: 0,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
 		It("Should get all Capps with a specific labelSelector in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CappsKey)
 			params := url.Values{}

--- a/test/e2e_tests/capprevision.go
+++ b/test/e2e_tests/capprevision.go
@@ -30,6 +30,74 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 	})
 
 	Context("Validate get CappRevisions route", func() {
+
+		It("Should get all CappRevisions in a namespace with limit of 50", func() {
+			limit := "50"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: append(oneCappRevisionNames, secondCappRevisionNames...),
+				testutils.CountKey:         2,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one CappRevisions in a namespace with limit of 1 and page 1", func() {
+			limit := "1"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: oneCappRevisionNames,
+				testutils.CountKey:         1,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one CappRevisions in a namespace with limit of 1 and page 2", func() {
+			limit := "1"
+			page := "2"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: secondCappRevisionNames,
+				testutils.CountKey:         1,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should not get CappRevisions with limit of 1 and page 10000", func() {
+			limit := "1"
+			page := "10000"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: nil,
+				testutils.CountKey:         0,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
 		It("Should get all CappRevisions in a namespace", func() {
 			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)

--- a/test/e2e_tests/secret.go
+++ b/test/e2e_tests/secret.go
@@ -53,6 +53,94 @@ var _ = Describe("Validate Secret routes and functionality", func() {
 			Expect(status).Should(Equal(http.StatusOK))
 			compareResponses(response, expectedResponse)
 		})
+
+		It("Should get all secrets in a namespace with limit of 50", func() {
+			limit := "50"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.SecretsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CountKey: 2,
+				testutils.SecretsKey: []map[string]interface{}{
+					{
+						testutils.SecretNameKey:    oneSecretName,
+						testutils.NamespaceNameKey: namespaceName,
+						testutils.TypeKey:          string(corev1.SecretTypeOpaque),
+					},
+					{
+						testutils.SecretNameKey:    secondSecretName,
+						testutils.NamespaceNameKey: namespaceName,
+						testutils.TypeKey:          string(corev1.SecretTypeOpaque),
+					},
+				},
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one secret in a namespace with limit of 1 and page 1", func() {
+			limit := "1"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.SecretsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CountKey: 1,
+				testutils.SecretsKey: []map[string]interface{}{
+					{
+						testutils.SecretNameKey:    oneSecretName,
+						testutils.NamespaceNameKey: namespaceName,
+						testutils.TypeKey:          string(corev1.SecretTypeOpaque),
+					},
+				},
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one secret in a namespace with limit of 1 and page 2", func() {
+			limit := "1"
+			page := "2"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.SecretsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CountKey: 1,
+				testutils.SecretsKey: []map[string]interface{}{
+					{
+						testutils.SecretNameKey:    secondSecretName,
+						testutils.NamespaceNameKey: namespaceName,
+						testutils.TypeKey:          string(corev1.SecretTypeOpaque),
+					},
+				},
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should not get secrets with limit of 1 and page 3", func() {
+			limit := "1"
+			page := "3"
+
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.SecretsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CountKey:   0,
+				testutils.SecretsKey: nil,
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
 	})
 
 	Context("Validate get Secret route", func() {


### PR DESCRIPTION
This PR adds pagination support for the `capp`, `capprevisions`, `users`, `pods`, `namespaces`, and `secrets` API resources. 
Key changes include:

* Pagination Middleware: Sets pagination parameters in the context.
 * pagination package:
    * Paginator interface: Defines BuildList for resource list fetching.
    * GenericPaginator struct: Handles pagination with context and logger.
    * CreatePaginator function: Creates a GenericPaginator.
    * buildListOptions function: Constructs ListOptions with pagination settings.
    * FetchPage and fetchItems functions: Retrieve and paginate items.
    * extractLimitFromCtx and extractPageFromCtx functions: Extract pagination parameters from the Gin context.