### PR TITLE
feat: implement get token from service account

### DIFF
--- a/docs/api/token.md
+++ b/docs/api/token.md
@@ -17,22 +17,17 @@
   - **Response**: Confirmation of creation or an error message.
     ```json
     {
-      "serviceAccountName": "string",
+      "serviceAccountName": "string"
     }
     ```
 
-- **GET** `/v1/namespaces/{namespace}/token`
+- **GET** `/v1/namespaces/{namespace}/serviceaccounts/{serviceAccountName}/token`
   - **Description**: Gets a new token from the service account.
   - **Path Parameter**:
     - `namespace` - The namespace of the service account to create token from.
-  - **Body**:
-    ```json
-    {
-      "serviceAccountName": "string"
-    }
   - **Response**: Token from the created service account.
     ```json
     {
-      "token": "string",
+      "token": "string"
     }
     ```

--- a/src/controllers/logs.go
+++ b/src/controllers/logs.go
@@ -60,7 +60,7 @@ func FetchCappLogs(ctx context.Context, client kubernetes.Interface, namespace, 
 }
 
 // FetchCappPodName returns the validated pod name from the provided list of pods.
-// If cappName is empty, it returns the name of the first pod in the list.
+// If name is empty, it returns the name of the first pod in the list.
 // It also returns a boolean indicating if the pod name was found in the list.
 func FetchCappPodName(podName string, pods *corev1.PodList) (string, bool) {
 	if podName == "" {

--- a/src/controllers/serviceaccounts.go
+++ b/src/controllers/serviceaccounts.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/types"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	tokenKey = "token"
+)
+
+const (
+	ErrCouldNotGetServiceAccount = "Could not get ServiceAccount %q in namespace %q"
+	ErrNoTokenFound              = "no token found for ServiceAccount %s"
+)
+
+// NewServiceAccountController creates a new instance of ServiceAccountController.
+func NewServiceAccountController(client kubernetes.Interface, context context.Context, logger *zap.Logger) ServiceAccountController {
+	return &serviceAccountController{
+		client: client,
+		ctx:    context,
+		logger: logger,
+	}
+}
+
+// serviceAccount implements the ServiceAccountController interface.
+type serviceAccountController struct {
+	client kubernetes.Interface
+	ctx    context.Context
+	logger *zap.Logger
+}
+
+// ServiceAccountController defines methods to interact with ServiceAccounts.
+type ServiceAccountController interface {
+	GetServiceAccount(name, namespace string) (*corev1.ServiceAccount, error)
+	GetServiceAccountToken(serviceAccountName, namespace string) (types.TokenResponse, error)
+	getServiceAccountToken(serviceAccount *corev1.ServiceAccount, namespace string) (string, error)
+}
+
+// GetServiceAccount retrieves a ServiceAccount by name and namespace, returning the ServiceAccount and any error encountered.
+func (c *serviceAccountController) GetServiceAccount(name, namespace string) (*corev1.ServiceAccount, error) {
+	c.logger.Debug(fmt.Sprintf("Trying to get service account: %q", name))
+
+	serviceAccount, err := c.client.CoreV1().ServiceAccounts(namespace).Get(c.ctx, name, metav1.GetOptions{})
+	if err != nil {
+		c.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetServiceAccount, name, namespace), err.Error()))
+		return &corev1.ServiceAccount{}, customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetServiceAccount, name, namespace), err)
+	}
+
+	return serviceAccount, nil
+}
+
+// GetServiceAccountToken retrieves the token for a given ServiceAccount by name and namespace, returning the token and any error encountered.
+func (c *serviceAccountController) GetServiceAccountToken(serviceAccountName, namespace string) (types.TokenResponse, error) {
+	serviceAccount, err := c.GetServiceAccount(serviceAccountName, namespace)
+	if err != nil {
+		return types.TokenResponse{}, err
+	}
+
+	token, err := c.getServiceAccountToken(serviceAccount, namespace)
+	if err != nil {
+		return types.TokenResponse{}, err
+	}
+
+	return types.TokenResponse{
+		Token: token,
+	}, nil
+}
+
+// getServiceAccountToken extracts the token from a ServiceAccount's associated secrets, returning the token and any error encountered.
+func (c *serviceAccountController) getServiceAccountToken(serviceAccount *corev1.ServiceAccount, namespace string) (string, error) {
+	for _, ref := range serviceAccount.Secrets {
+		secret, err := c.client.CoreV1().Secrets(namespace).Get(c.ctx, ref.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		if secret.Type == corev1.SecretTypeDockercfg {
+			for _, ownerRef := range secret.OwnerReferences {
+				tokenSecret, err := c.client.CoreV1().Secrets(namespace).Get(c.ctx, ownerRef.Name, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				if tokenSecret.Type == corev1.SecretTypeServiceAccountToken {
+					return string(tokenSecret.Data[tokenKey]), nil
+				}
+			}
+		}
+	}
+
+	return "", customerrors.NewValidationError(fmt.Sprintf(ErrNoTokenFound, serviceAccount.Name))
+}

--- a/src/controllers/serviceaccounts_test.go
+++ b/src/controllers/serviceaccounts_test.go
@@ -1,0 +1,136 @@
+package controllers
+
+import (
+	"fmt"
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetServiceAccount(t *testing.T) {
+	namespaceName := testutils.TestNamespace + "-getServiceAccount"
+	type args struct {
+		namespace string
+		name      string
+	}
+	type want struct {
+		serviceAccount *corev1.ServiceAccount
+		error          string
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldSucceedGettingServiceAccount": {
+			args: args{
+				namespace: namespaceName,
+				name:      testutils.ServiceAccountName,
+			},
+			want: want{
+				serviceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testutils.ServiceAccountName,
+						Namespace: namespaceName,
+					},
+					Secrets: []corev1.ObjectReference{
+						{
+							Kind:      testutils.Secret,
+							Name:      "docker-cfg",
+							Namespace: namespaceName,
+						},
+					},
+				},
+			},
+		},
+		"ShouldNotFindServiceAccountInNonExistingNamespace": {
+			args: args{
+				name:      testutils.CappName + testutils.NonExistentSuffix,
+				namespace: namespaceName + testutils.NonExistentSuffix,
+			},
+			want: want{
+				serviceAccount: &corev1.ServiceAccount{},
+				error:          fmt.Sprintf(ErrCouldNotGetServiceAccount, testutils.CappName+testutils.NonExistentSuffix, namespaceName+testutils.NonExistentSuffix),
+			},
+		},
+	}
+
+	setup()
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	mocks.CreateTestServiceAccountWithToken(fakeClient, namespaceName, testutils.ServiceAccountName, "token-secret", "value", "docker-cfg")
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := mocks.GinContext()
+			serviceAccountController := NewServiceAccountController(fakeClient, c, logger)
+			response, err := serviceAccountController.GetServiceAccount(test.args.name, test.args.namespace)
+
+			if test.want.error != "" {
+				assert.ErrorContains(t, err, test.want.error)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.serviceAccount, response)
+		})
+	}
+}
+
+func TestGetServiceAccountToken(t *testing.T) {
+	namespaceName := testutils.TestNamespace + "-getServiceAccount"
+	type args struct {
+		namespace string
+		name      string
+	}
+	type want struct {
+		tokenResponse types.TokenResponse
+		error         string
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldSucceedGettingServiceAccount": {
+			args: args{
+				namespace: namespaceName,
+				name:      testutils.ServiceAccountName,
+			},
+			want: want{
+				tokenResponse: types.TokenResponse{
+					Token: "value",
+				},
+			},
+		},
+		"ShouldNotFindServiceAccountInNonExistingNamespace": {
+			args: args{
+				name:      testutils.CappName + testutils.NonExistentSuffix,
+				namespace: namespaceName + testutils.NonExistentSuffix,
+			},
+			want: want{
+				error: fmt.Sprintf(ErrCouldNotGetServiceAccount, testutils.CappName+testutils.NonExistentSuffix, namespaceName+testutils.NonExistentSuffix),
+			},
+		},
+	}
+
+	setup()
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	mocks.CreateTestServiceAccountWithToken(fakeClient, namespaceName, testutils.ServiceAccountName, "token-secret", "value", "docker-cfg")
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := mocks.GinContext()
+			serviceAccountController := NewServiceAccountController(fakeClient, c, logger)
+			response, err := serviceAccountController.GetServiceAccountToken(test.args.name, test.args.namespace)
+
+			if test.want.error != "" {
+				assert.ErrorContains(t, err, test.want.error)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.want.tokenResponse, response)
+		})
+	}
+}

--- a/src/routes/v1/serviceaccounts.go
+++ b/src/routes/v1/serviceaccounts.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"github.com/dana-team/platform-backend/src/controllers"
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/routes"
+	"github.com/dana-team/platform-backend/src/types"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// serviceAccountHandler wraps a handler function with context setup for serviceAccountController.
+func serviceAccountHandler(handler func(controller controllers.ServiceAccountController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		kubeClient, err := routes.GetKubeClient(c)
+		if routes.AddErrorToContext(c, err) {
+			return
+		}
+
+		logger, err := routes.GetLogger(c)
+		if routes.AddErrorToContext(c, err) {
+			return
+		}
+
+		context := c.Request.Context()
+		serviceAccountController := controllers.NewServiceAccountController(kubeClient, context, logger)
+
+		result, err := handler(serviceAccountController, c)
+		if routes.AddErrorToContext(c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, result)
+	}
+}
+
+// GetToken returns a Gin handler function for retrieving token of a specific service account.
+func GetToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var request types.ServiceAccountRequestUri
+		if err := c.BindUri(&request); err != nil {
+			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			return
+		}
+
+		serviceAccountHandler(func(controller controllers.ServiceAccountController, c *gin.Context) (interface{}, error) {
+			return controller.GetServiceAccountToken(request.ServiceAccountName, request.NamespaceName)
+		})(c)
+	}
+}

--- a/src/routes/v1/serviceaccounts_test.go
+++ b/src/routes/v1/serviceaccounts_test.go
@@ -1,0 +1,112 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dana-team/platform-backend/src/controllers"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	serviceAccountNamespace = testutils.TestNamespace + testutils.TokenKey
+)
+
+func TestGetServiceAccountToken(t *testing.T) {
+	testNamespaceName := serviceAccountNamespace + "-get-token"
+
+	type args struct {
+		serviceAccountName string
+		namespace          string
+	}
+
+	type want struct {
+		statusCode int
+		response   map[string]interface{}
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldSucceedGettingToken": {
+			args: args{
+				namespace:          testNamespaceName,
+				serviceAccountName: testutils.ServiceAccountName,
+			},
+			want: want{
+				statusCode: http.StatusOK,
+				response: map[string]interface{}{
+					testutils.TokenKey: testutils.Value,
+				},
+			},
+		},
+		"ShouldNotSucceedGettingTokenForNonExistingNamespace": {
+			args: args{
+				namespace:          testNamespaceName + testutils.NonExistentSuffix,
+				serviceAccountName: testutils.ServiceAccountName,
+			},
+			want: want{
+				statusCode: http.StatusNotFound,
+				response: map[string]interface{}{
+					testutils.ErrorKey: fmt.Sprintf("%s, %s",
+						fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, testutils.ServiceAccountName, testNamespaceName+testutils.NonExistentSuffix),
+						fmt.Sprintf("serviceaccounts %q not found", testutils.ServiceAccountName),
+					),
+					testutils.ReasonKey: testutils.ReasonNotFound,
+				},
+			},
+		},
+		"ShouldNotSucceedGettingTokenForNonExistingName": {
+			args: args{
+				namespace:          testNamespaceName,
+				serviceAccountName: testutils.ServiceAccountName + testutils.NonExistentSuffix,
+			},
+			want: want{
+				statusCode: http.StatusNotFound,
+				response: map[string]interface{}{
+					testutils.ErrorKey: fmt.Sprintf("%s, %s",
+						fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, testutils.ServiceAccountName+testutils.NonExistentSuffix, testNamespaceName),
+						fmt.Sprintf("serviceaccounts %q not found", testutils.ServiceAccountName+testutils.NonExistentSuffix),
+					),
+					testutils.ReasonKey: testutils.ReasonNotFound,
+				},
+			},
+		},
+	}
+
+	setup()
+	mocks.CreateTestNamespace(fakeClient, testNamespaceName)
+	mocks.CreateTestServiceAccountWithToken(fakeClient, testNamespaceName, testutils.ServiceAccountName, "token-secret", "value", "docker-cfg")
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			params := url.Values{}
+
+			baseURI := fmt.Sprintf("/v1/namespaces/%s/serviceaccounts/%s/token", test.args.namespace, test.args.serviceAccountName)
+			request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s?%s", baseURI, params.Encode()), nil)
+			assert.NoError(t, err)
+			writer := httptest.NewRecorder()
+			router.ServeHTTP(writer, request)
+
+			assert.Equal(t, test.want.statusCode, writer.Code)
+
+			var response map[string]interface{}
+			err = json.Unmarshal(writer.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			wantResponseJSON, err := json.Marshal(test.want.response)
+			assert.NoError(t, err)
+			var wantResponseNormalized map[string]interface{}
+			err = json.Unmarshal(wantResponseJSON, &wantResponseNormalized)
+			assert.NoError(t, err)
+			assert.Equal(t, wantResponseNormalized, response)
+		})
+	}
+}

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -96,4 +96,10 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 	{
 		podsGroup.Use(middleware.PaginationMiddleware()).GET("/capps/:cappName/pods", GetPods())
 	}
+
+	serviceAccountsGroup := namespacesGroup.Group("/:namespaceName/serviceaccounts")
+	serviceAccountsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
+	{
+		serviceAccountsGroup.GET("/:serviceAccountName/token", GetToken())
+	}
 }

--- a/src/routes/v1/setup_test.go
+++ b/src/routes/v1/setup_test.go
@@ -112,6 +112,11 @@ func setupRouter(logger *zap.Logger) *gin.Engine {
 			{
 				podsGroup.Use(middleware.PaginationMiddleware()).GET("/capps/:cappName/pods", GetPods())
 			}
+
+			serviceAccountsGroup := namespacesGroup.Group("/:namespaceName/serviceaccounts")
+			{
+				serviceAccountsGroup.GET("/:serviceAccountName/token", GetToken())
+			}
 		}
 	}
 	return engine

--- a/src/types/serviceaccounts.go
+++ b/src/types/serviceaccounts.go
@@ -1,0 +1,10 @@
+package types
+
+type ServiceAccountRequestUri struct {
+	NamespaceName      string `uri:"namespaceName" binding:"required"`
+	ServiceAccountName string `uri:"serviceAccountName" binding:"required"`
+}
+
+type TokenResponse struct {
+	Token string `json:"token"`
+}

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -41,6 +41,14 @@ const (
 )
 
 const (
+	ServiceAccountsKey = "serviceaccounts"
+	TokenKey           = "token"
+	Secret             = "Secret"
+	V1 = "v1"
+	Value = "value"
+)
+
+const (
 	RoleKey              = "role"
 	AdminKey             = "admin"
 	ViewerKey            = "viewer"
@@ -108,6 +116,11 @@ const (
 
 const (
 	CappResourceKey = "rcs.dana.io/parent-capp"
+)
+
+const (
+	ServiceAccountName       = TestName + "-serviceAccount"
+	ServiceAccountAnnotation = "kubernetes.io/service-account.name"
 )
 
 const (

--- a/src/utils/testutils/mocks/adapter.go
+++ b/src/utils/testutils/mocks/adapter.go
@@ -109,3 +109,31 @@ func CreateTestCNAMERecordWithoutConditions(dynClient runtimeClient.WithWatch, n
 		panic(err)
 	}
 }
+
+// CreateTestServiceAccount creates a test service account
+func CreateTestServiceAccount(fakeClient *fake.Clientset, namespace, name string, dockerCfgSecretName string) {
+	serviceAccount := PrepareServiceAccount(name, namespace, dockerCfgSecretName)
+	_, err := fakeClient.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// CreateTestServiceAccountWithToken creates a test service account
+func CreateTestServiceAccountWithToken(fakeClient *fake.Clientset, namespace, serviceAccountName, tokenSecretName, tokenValue, dockerCfgSecretName string) {
+	tokenSecret := PrepareTokenSecret(tokenSecretName, namespace, tokenValue, serviceAccountName)
+	createTestSecret(fakeClient, tokenSecret)
+
+	dockerCfgSecret := PrepareDockerConfigSecret(dockerCfgSecretName, namespace, tokenSecretName)
+	createTestSecret(fakeClient, dockerCfgSecret)
+
+	CreateTestServiceAccount(fakeClient, namespace, serviceAccountName, dockerCfgSecretName)
+}
+
+// createTestSecret receives a secret and creates it.
+func createTestSecret(fakeClient *fake.Clientset, secret corev1.Secret) {
+	_, err := fakeClient.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/src/utils/testutils/mocks/secret.go
+++ b/src/utils/testutils/mocks/secret.go
@@ -22,6 +22,41 @@ func PrepareSecret(name, namespace, dataKey, dataValue string) corev1.Secret {
 	}
 }
 
+// PrepareTokenSecret returns a mock token secret object.
+func PrepareTokenSecret(name, namespace, tokenValue, serviceAccountName string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				testutils.ServiceAccountAnnotation: serviceAccountName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: map[string][]byte{
+			testutils.TokenKey: []byte(tokenValue),
+		},
+	}
+}
+
+// PrepareDockerConfigSecret returns a mock docker config secret object.
+func PrepareDockerConfigSecret(name, namespace, serviceAccountTokenSecretName string) corev1.Secret {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: testutils.V1,
+		Kind:       testutils.Secret,
+		Name:       serviceAccountTokenSecretName,
+	}
+
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Type: corev1.SecretTypeDockercfg,
+	}
+}
+
 // PrepareCreateSecretRequestType returns a Secret Request type object.
 func PrepareCreateSecretRequestType(name, secretType, cert, key string, data []types.KeyValue) types.CreateSecretRequest {
 	return types.CreateSecretRequest{

--- a/src/utils/testutils/mocks/serviceaccount.go
+++ b/src/utils/testutils/mocks/serviceaccount.go
@@ -1,0 +1,29 @@
+package mocks
+
+import (
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PrepareServiceAccount returns a mock ServiceAccount object.
+func PrepareServiceAccount(name, namespace string, dockerCfgSecretName string) *corev1.ServiceAccount {
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	if dockerCfgSecretName != "" {
+		serviceAccount.Secrets = []corev1.ObjectReference{
+			{
+				Kind:      testutils.Secret,
+				Name:      dockerCfgSecretName,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	return serviceAccount
+}

--- a/test/e2e_tests/helper.go
+++ b/test/e2e_tests/helper.go
@@ -16,16 +16,17 @@ import (
 )
 
 const (
-	e2eUser              = "e2e-user"
-	e2ePassword          = "e2e-password"
-	e2eNamespace         = "e2e-namespace"
-	e2eLabelKey          = "e2e-label-key"
-	e2eLabelValue        = "e2e-label-value"
-	testCappName         = "e2e-capp"
-	testCappRevisionName = "e2e-capp-revision"
-	testConfigMapName    = "e2e-configmap"
-	testSecretName       = "e2e-secret"
-	testUserName         = "e2e-user"
+	e2eUser                = "e2e-user"
+	e2ePassword            = "e2e-password"
+	e2eNamespace           = "e2e-namespace"
+	e2eLabelKey            = "e2e-label-key"
+	e2eLabelValue          = "e2e-label-value"
+	testCappName           = "e2e-capp"
+	testCappRevisionName   = "e2e-capp-revision"
+	testConfigMapName      = "e2e-configmap"
+	testServiceAccountName = "e2e-serviceaccount"
+	testSecretName         = "e2e-secret"
+	testUserName           = "e2e-user"
 )
 
 const (

--- a/test/e2e_tests/serviceaccounts.go
+++ b/test/e2e_tests/serviceaccounts.go
@@ -1,0 +1,64 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"github.com/dana-team/platform-backend/src/controllers"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Validate ServiceAccounts routes and functionality", func() {
+	var namespaceName, serviceAccountName string
+
+	BeforeEach(func() {
+		namespaceName = generateName(e2eNamespace)
+		createTestNamespace(k8sClient, namespaceName)
+
+		serviceAccountName = generateName(testServiceAccountName)
+		CreateTestServiceAccount(k8sClient, serviceAccountName, namespaceName, "token-secret", "value", "docker-cfg")
+	})
+
+	Context("Validate get ServiceAccount token route", func() {
+		It("Should get token from service account", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountsKey, serviceAccountName)
+			fmt.Println(uri)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			tokenSecret := getServiceAccountTokenSecret(k8sClient, serviceAccountName, namespaceName)
+			expectedResponse := map[string]interface{}{
+				testutils.TokenKey: string(tokenSecret.Data[testutils.TokenKey]),
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a not found ServiceAccount in a namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountsKey, serviceAccountName+testutils.NonExistentSuffix)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, serviceAccountName+testutils.NonExistentSuffix, namespaceName),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a get of a ServiceAccount in a not found namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.ServiceAccountsKey, serviceAccountName)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, serviceAccountName, namespaceName+testutils.NonExistentSuffix),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+	})
+})


### PR DESCRIPTION
This PR introduces the route: `GET /v1/namespaces/{namespace}/serviceaccounts/{serviceAccountName}/token`. 
This endpoint allows users to retrieve the token associated with a specified service account.