### PR TITLE
feat: implement multi cluster support

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,8 +1,6 @@
 name: lint
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, reopened, synchronize]
 permissions:
   contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,6 @@
 name: tests
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, reopened, synchronize]
 
 jobs:
@@ -81,7 +79,7 @@ jobs:
         run: | 
           make setup-hub \
           PLACEMENT_NAME=test-ci \
-          PLACEMENT_NAMESPACES=test-ci-ns \
+          PLACEMENTS_NAMESPACE=test-ci-ns \
           MANAGED_CLUSTER_NAME=${{ secrets.BACKEND_CI_CLUSTER_NAME }}
 
       - name: Await rcs addons to be ready
@@ -109,7 +107,7 @@ jobs:
         run: |
           make cleanup-hub \
           PLACEMENT_NAME=test-ci \
-          PLACEMENT_NAMESPACES=test-ci-ns \
+          PLACEMENTS_NAMESPACE=test-ci-ns \
           MANAGED_CLUSTER_NAME=${{ secrets.BACKEND_CI_CLUSTER_NAME }}
         if: always()
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/oam-dev/cluster-gateway v1.6.0
 	github.com/onsi/ginkgo/v2 v2.19.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v0.0.0-20240508125607-95e22923d553

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oam-dev/cluster-gateway v1.6.0 h1:dWQfPSV0QE27hPNS+3pjoq/vsi1PIwlqaQhtVxgBKmw=
+github.com/oam-dev/cluster-gateway v1.6.0/go.mod h1:FSOI72SXktmqz91/CpDMAi2jYnMsUSb+O/DbaNLuhaw=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.19.1 h1:QXgq3Z8Crl5EL1WBAC98A5sEBHARrAJNzAmMxzLcRF0=

--- a/hack/managed-cluster-setup/cluster-gateway-rbac.yaml
+++ b/hack/managed-cluster-setup/cluster-gateway-rbac.yaml
@@ -1,0 +1,40 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-gateway-cluster-role
+rules:
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - rcs.dana.io
+    resources:
+      - capps
+      - capprevisions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - record.dns.crossplane.io
+    resources:
+      - cnamerecords
+      - cnamerecords/status
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-gateway-role-binding-cluster
+subjects:
+  - kind: ServiceAccount
+    name: cluster-gateway
+    namespace: open-cluster-management-managed-serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-gateway-cluster-role

--- a/hack/managed-cluster-setup/cluster-proxy-rbac.yaml
+++ b/hack/managed-cluster-setup/cluster-proxy-rbac.yaml
@@ -1,0 +1,40 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-proxy-cluster-role
+rules:
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - rcs.dana.io
+    resources:
+      - capps
+      - capprevisions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - record.dns.crossplane.io
+    resources:
+      - cnamerecords
+      - cnamerecords/status
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-proxy-role-binding-cluster
+subjects:
+  - kind: ServiceAccount
+    name: cluster-proxy
+    namespace: open-cluster-management-agent-addon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-proxy-cluster-role

--- a/src/middleware/auth_middleware_test.go
+++ b/src/middleware/auth_middleware_test.go
@@ -42,6 +42,7 @@ func TestTokenAuthMiddleware(t *testing.T) {
 		c.Next()
 	})
 
+	router.Use(ErrorHandlingMiddleware())
 	router.Use(TokenAuthMiddleware(MockTokenProvider{Token: "valid_token", Username: "user", Err: nil}, newScheme()))
 	router.GET("/ping", func(c *gin.Context) {
 		_, ok := c.Get("kubeClient")

--- a/src/middleware/cluster_middleware.go
+++ b/src/middleware/cluster_middleware.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/gin-gonic/gin"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ClusterCtxKey = "cluster"
+	cappName      = "cappName"
+	namespaceName = "namespaceName"
+	clusterName   = "clusterName"
+)
+
+const (
+	errNoClusterOrNameAndNamespaceProvided = "either 'cluster' must be provided, or both 'cappName' and 'namespace' must be provided."
+)
+
+// ClusterMiddleware retrieves the cluster based on capp and adds it to the request context.
+func ClusterMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cluster := c.Param(clusterName)
+		name := c.Param(cappName)
+		namespace := c.Param(namespaceName)
+
+		if cluster == "" && (name == "" || namespace == "") {
+			err := customerrors.NewValidationError(errNoClusterOrNameAndNamespaceProvided)
+			AddErrorToContext(c, err)
+			c.Abort()
+			return
+		}
+
+		if name != "" && namespace != "" {
+			capp, err := getCapp(c, name, namespace)
+			if AddErrorToContext(c, err) {
+				c.Abort()
+				return
+			}
+			cluster = capp.Status.ApplicationLinks.Site
+		}
+
+		c.Set(ClusterCtxKey, cluster)
+		c.Next()
+	}
+}
+
+// getCapp retrieves a Capp object from the Kubernetes cluster based on the provided name and namespace.
+func getCapp(c *gin.Context, name, namespace string) (*cappv1alpha1.Capp, error) {
+	capp := &cappv1alpha1.Capp{}
+	kubeClient, err := GetDynClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = kubeClient.Get(c.Request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, capp)
+	if err != nil {
+		return nil, err
+	}
+
+	return capp, nil
+}

--- a/src/middleware/cluster_middleware_test.go
+++ b/src/middleware/cluster_middleware_test.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+)
+
+// errorMiddlewareForTest is a middleware for tests that captures errors and returns a response if an error occurs, ignoring `NotFoundError`.
+func errorMiddlewareForTest() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		if !hasErrors(c) {
+			return
+		}
+
+		lastError := c.Errors.Last()
+		var notFoundError *customerrors.NotFoundError
+
+		// If either clusterName was received, or both cappName and namespaceName were received,
+		// and Capp was not found, return valid response to avoid fakeClient setup.
+		if errors.As(lastError.Err, &notFoundError) {
+			c.JSON(http.StatusOK, gin.H{
+				"message": "pong",
+			})
+			return
+		}
+
+		c.JSON(http.StatusBadRequest, gin.H{
+			errorKey: lastError.Err.Error(),
+			reason:   notFoundError.StatusReason(),
+		})
+		c.Next()
+	}
+}
+
+func Test_ClusterMiddleware(t *testing.T) {
+	router := gin.New()
+	router.Use(errorMiddlewareForTest()) // Use the error middleware for test scenarios
+
+	router.Use(ClusterMiddleware()).GET("/namespaces/:namespaceName/capps/:cappName", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "pong",
+		})
+	})
+
+	var notFoundError = customerrors.NewNotFoundError("error")
+
+	type args struct {
+		path string
+	}
+	type want struct {
+		expectedStatus int
+		expectedBody   string
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldSuccess": {
+			args: args{
+				path: "/namespaces/namespace/capps/capp",
+			},
+			want: want{
+				expectedStatus: http.StatusOK,
+				expectedBody:   `{"message":"pong"}`,
+			},
+		},
+		"ShouldFailOnNoNamespace": {
+			args: args{
+				path: "/namespaces//capps/capp",
+			},
+			want: want{
+				expectedStatus: http.StatusBadRequest,
+				expectedBody:   fmt.Sprintf(`{"error":%q,"reason":%q}`, errNoClusterOrNameAndNamespaceProvided, notFoundError.StatusReason()),
+			},
+		},
+		"ShouldFailOnNoName": {
+			args: args{
+				path: "/namespaces/namespace/capps/",
+			},
+			want: want{
+				expectedStatus: http.StatusBadRequest,
+				expectedBody:   fmt.Sprintf(`{"error":%q,"reason":%q}`, errNoClusterOrNameAndNamespaceProvided, notFoundError.StatusReason()),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.args.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tc.want.expectedStatus {
+				t.Errorf("Expected status code %d; got %d", tc.want.expectedStatus, w.Code)
+			}
+
+			actualBody := w.Body.String()
+			if actualBody != tc.want.expectedBody {
+				t.Errorf("Expected body %s; got %s", tc.want.expectedBody, actualBody)
+			}
+		})
+	}
+}

--- a/src/middleware/context.go
+++ b/src/middleware/context.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetKubeClient retrieves the Kubernetes client from the gin.Context.
+func GetKubeClient(c *gin.Context) (kubernetes.Interface, error) {
+	kube, exists := c.Get(KubeClientCtxKey)
+	if !exists {
+		return nil, c.Error(customerrors.NewNotFoundError("kubernetes client not found in context"))
+	}
+	return kube.(kubernetes.Interface), nil
+}
+
+// GetDynClient retrieves the dynamic client from the gin.Context.
+func GetDynClient(c *gin.Context) (client.Client, error) {
+	kube, exists := c.Get(DynamicClientCtxKey)
+	if !exists {
+		return nil, c.Error(customerrors.NewNotFoundError("dynamic client not found in context"))
+	}
+	return kube.(client.Client), nil
+}
+
+// GetLogger retrieves the logger from the gin.Context.
+func GetLogger(c *gin.Context) (*zap.Logger, error) {
+	logger, exists := c.Get(LoggerCtxKey)
+	if !exists {
+		return nil, c.Error(customerrors.NewNotFoundError("logger not found in context"))
+	}
+	return logger.(*zap.Logger), nil
+}
+
+// GetCluster retrieves the cluster from the gin.Context.
+func GetCluster(c *gin.Context) (string, bool) {
+	cluster, exists := c.Get(ClusterCtxKey)
+	if !exists {
+		return "", false
+	}
+
+	return cluster.(string), true
+}
+
+// AddErrorToContext checks if the error is non-nil and adds it to the Gin context if so.
+func AddErrorToContext(c *gin.Context, err error) bool {
+	if err != nil {
+		// Add the error to the Gin context for further handling. Ignoring the return value as no action is needed based on it.
+		_ = c.Error(err)
+		return true
+	}
+	return false
+}

--- a/src/routes/context.go
+++ b/src/routes/context.go
@@ -1,47 +1,20 @@
 package routes
 
 import (
-	"github.com/dana-team/platform-backend/src/customerrors"
+	"context"
 	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	multicluster "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/transport"
 )
 
-// GetKubeClient retrieves the Kubernetes client from the gin.Context.
-func GetKubeClient(c *gin.Context) (kubernetes.Interface, error) {
-	kube, exists := c.Get(middleware.KubeClientCtxKey)
-	if !exists {
-		return nil, c.Error(customerrors.NewNotFoundError("kubernetes client not found in context"))
-	}
-	return kube.(kubernetes.Interface), nil
-}
+// GetContext returns the context from the gin.Context, containing the managed cluster if available.
+func GetContext(c *gin.Context) context.Context {
+	ctx := c.Request.Context()
 
-// GetDynClient retrieves the dynamic client from the gin.Context.
-func GetDynClient(c *gin.Context) (client.Client, error) {
-	kube, exists := c.Get(middleware.DynamicClientCtxKey)
+	cluster, exists := middleware.GetCluster(c)
 	if !exists {
-		return nil, c.Error(customerrors.NewNotFoundError("dynamic client not found in context"))
+		return ctx
 	}
-	return kube.(client.Client), nil
-}
 
-// GetLogger retrieves the logger from the gin.Context.
-func GetLogger(c *gin.Context) (*zap.Logger, error) {
-	logger, exists := c.Get(middleware.LoggerCtxKey)
-	if !exists {
-		return nil, c.Error(customerrors.NewNotFoundError("logger not found in context"))
-	}
-	return logger.(*zap.Logger), nil
-}
-
-// AddErrorToContext checks if the error is non-nil and adds it to the Gin context if so.
-func AddErrorToContext(c *gin.Context, err error) bool {
-	if err != nil {
-		// Add the error to the Gin context for further handling. Ignoring the return value as no action is needed based on it.
-		_ = c.Error(err)
-		return true
-	}
-	return false
+	return multicluster.WithMultiClusterContext(ctx, cluster)
 }

--- a/src/routes/v1/capp.go
+++ b/src/routes/v1/capp.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/routes"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
@@ -13,21 +14,21 @@ import (
 
 func cappHandler(handler func(controller controllers.CappController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetDynClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetDynClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		context := c.Request.Context()
+		context := routes.GetContext(c)
 		cappController := controllers.NewCappController(kubeClient, context, logger)
 
 		result, err := handler(cappController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -39,19 +40,19 @@ func GetCapps() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappNamespaceUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		var cappQuery types.CappQuery
 		if err := c.BindQuery(&cappQuery); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -65,7 +66,7 @@ func GetCapp() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -79,12 +80,12 @@ func CreateCapp() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappNamespaceUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var capp types.CreateCapp
 		if err := c.BindJSON(&capp); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -98,12 +99,12 @@ func UpdateCapp() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var capp types.UpdateCapp
 		if err := c.BindJSON(&capp); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -117,12 +118,12 @@ func EditCappState() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var state types.CappState
 		if err := c.BindJSON(&state); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -136,7 +137,7 @@ func GetCappState() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -150,7 +151,7 @@ func GetCappDNS() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -164,7 +165,7 @@ func DeleteCapp() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/capp_test.go
+++ b/src/routes/v1/capp_test.go
@@ -503,9 +503,7 @@ func TestGetCappDNS(t *testing.T) {
 			want: want{
 				statusCode: http.StatusNotFound,
 				response: map[string]interface{}{
-					testutils.ErrorKey: fmt.Sprintf("%v, %v",
-						fmt.Sprintf(controllers.ErrCouldNotGetCapp, testutils.CappName+testutils.NonExistentSuffix, testNamespaceName),
-						fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName+testutils.NonExistentSuffix)),
+					testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName+testutils.NonExistentSuffix),
 					testutils.ReasonKey: metav1.StatusReasonNotFound,
 				},
 			},
@@ -518,9 +516,7 @@ func TestGetCappDNS(t *testing.T) {
 			want: want{
 				statusCode: http.StatusNotFound,
 				response: map[string]interface{}{
-					testutils.ErrorKey: fmt.Sprintf("%v, %v",
-						fmt.Sprintf(controllers.ErrCouldNotGetCapp, testutils.CappName, testNamespaceName+testutils.NonExistentSuffix),
-						fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName)),
+					testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName),
 					testutils.ReasonKey: metav1.StatusReasonNotFound,
 				},
 			},

--- a/src/routes/v1/capprevision.go
+++ b/src/routes/v1/capprevision.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/routes"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
@@ -13,21 +14,21 @@ import (
 
 func cappRevisionHandler(handler func(controller controllers.CappRevisionController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetDynClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetDynClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		context := c.Request.Context()
+		context := routes.GetContext(c)
 		cappRevisionController := controllers.NewCappRevisionController(kubeClient, context, logger)
 
 		result, err := handler(cappRevisionController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -39,24 +40,18 @@ func GetCappRevisions() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappRevisionUri types.CappRevisionNamespaceUri
 		if err := c.BindUri(&cappRevisionUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
-			return
-		}
-
-		var cappRevisionQuery types.CappRevisionQuery
-		if err := c.BindQuery(&cappRevisionQuery); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		cappRevisionHandler(func(controller controllers.CappRevisionController, c *gin.Context) (interface{}, error) {
-			return controller.GetCappRevisions(cappRevisionUri.NamespaceName, limit, page, cappRevisionQuery)
+			return controller.GetCappRevisions(cappRevisionUri.NamespaceName, limit, page, cappRevisionUri.CappName)
 		})(c)
 	}
 }
@@ -65,7 +60,7 @@ func GetCappRevision() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cappUri types.CappRevisionUri
 		if err := c.BindUri(&cappUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/configmaps.go
+++ b/src/routes/v1/configmaps.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
-	"github.com/dana-team/platform-backend/src/routes"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"net/http"
 
 	"github.com/dana-team/platform-backend/src/controllers"
@@ -13,13 +13,13 @@ import (
 // configMapHandler handles the request of the client to the Kubernetes cluster.
 func configMapHandler(handler func(controller controllers.ConfigMapController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -27,7 +27,7 @@ func configMapHandler(handler func(controller controllers.ConfigMapController, c
 		configMapController := controllers.NewConfigMapController(kubeClient, context, logger)
 
 		result, err := handler(configMapController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -40,7 +40,7 @@ func GetConfigMap() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var uriRequest types.ConfigMapUri
 		if err := c.BindUri(&uriRequest); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/containers.go
+++ b/src/routes/v1/containers.go
@@ -2,9 +2,10 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/dana-team/platform-backend/src/routes"
 
 	"github.com/dana-team/platform-backend/src/controllers"
-	"github.com/dana-team/platform-backend/src/routes"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -13,21 +14,21 @@ import (
 // containerHandler wraps a handler function with context setup for ContainerController.
 func containerHandler(handler func(controller controllers.ContainerController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		context := c.Request.Context()
+		context := routes.GetContext(c)
 		containerController := controllers.NewContainerController(kubeClient, context, logger)
 
 		result, err := handler(containerController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -35,12 +36,12 @@ func containerHandler(handler func(controller controllers.ContainerController, c
 	}
 }
 
-// GetContainers returns a Gin handler function for retrieving containers information.
-func GetContainers() gin.HandlerFunc {
+// GetPodsContainers returns a Gin handler function for retrieving containers information.
+func GetPodsContainers() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request types.ContainerRequestUri
 		if err := c.BindUri(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/login.go
+++ b/src/routes/v1/login.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"github.com/dana-team/platform-backend/src/auth"
 	"github.com/dana-team/platform-backend/src/customerrors"
-	"github.com/dana-team/platform-backend/src/routes"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 	"net/http"
@@ -24,7 +24,7 @@ func Login(tokenProvider auth.TokenProvider) gin.HandlerFunc {
 		username, password, hasAuth := c.Request.BasicAuth()
 		if !hasAuth {
 			logger.Error(errAuthorizationHeaderNotFound)
-			routes.AddErrorToContext(c, customerrors.NewValidationError(errAuthorizationHeaderNotFound))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(errAuthorizationHeaderNotFound))
 			return
 		}
 
@@ -33,10 +33,10 @@ func Login(tokenProvider auth.TokenProvider) gin.HandlerFunc {
 		if err != nil {
 			if errors.Is(err, auth.ErrInvalidCredentials) {
 				logger.Warn("Invalid credentials provided", zap.Error(err))
-				routes.AddErrorToContext(c, customerrors.NewUnauthorizedError(err.Error()))
+				middleware.AddErrorToContext(c, customerrors.NewUnauthorizedError(err.Error()))
 			} else {
 				logger.Error("Failed to obtain OpenShift token", zap.Error(err))
-				routes.AddErrorToContext(c, customerrors.NewInternalServerError(err.Error()))
+				middleware.AddErrorToContext(c, customerrors.NewInternalServerError(err.Error()))
 			}
 			return
 		}

--- a/src/routes/v1/logs_stream_test.go
+++ b/src/routes/v1/logs_stream_test.go
@@ -41,7 +41,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldStreamLogsWithoutQueryParams": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs", testNamespaceGetCappLogs, testutils.CappName),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -51,7 +51,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldNotStreamLogsWithInvalidCappName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/invalid-capp",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/invalid-capp/logs", testNamespaceGetCappLogs),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -61,7 +61,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldStreamLogsWithQueryParams": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName + "?cappName=test-pod-2",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs?podName=test-pod-2", testNamespaceGetCappLogs, testutils.CappName),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -71,7 +71,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldStreamLogsWithPreviousQueryParam": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName + "?previous=true",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs?previous=true", testNamespaceGetCappLogs, testutils.CappName),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -81,7 +81,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldNotStreamLogsWithNonExistingPodName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName + "?cappName=pod" + testutils.NonExistentSuffix,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs?podName=pod%s", testNamespaceGetCappLogs, testutils.CappName, testutils.NonExistentSuffix),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -91,7 +91,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldNotStreamLogsWithInvalidContainerName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName + "?container=container" + testutils.NonExistentSuffix,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs?container=container%s", testNamespaceGetCappLogs, testutils.CappName, testutils.NonExistentSuffix),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -101,7 +101,7 @@ func Test_GetCappLogs(t *testing.T) {
 		"ShouldStreamLogsWithValidContainerName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/capp/" + testNamespaceGetCappLogs + "/" + testutils.CappName + "?container=test-container",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/%s/logs?container=test-container", testNamespaceGetCappLogs, testutils.CappName),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -167,7 +167,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldStreamLogsWithoutQueryParams": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + pod1,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/%s/logs", testNamespaceGetPodLogs, pod1),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -177,7 +177,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldStreamLogsWithQueryParams": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + pod1 + "?container=test-container",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/%s/logs?container=test-container", testNamespaceGetPodLogs, pod1),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -187,7 +187,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldStreamLogsWithPreviousQueryParam": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + pod1 + "?previous=true",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/%s/logs?previous=true", testNamespaceGetPodLogs, pod1),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -197,7 +197,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldStreamLogsWithoutQueryParamsMultipleContainers": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + pod3,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/%s/logs", testNamespaceGetPodLogs, pod3),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -207,7 +207,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldNotStreamLogsWithNonExistingPodName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + "test-invalid-pod",
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/test-invalid-pod/logs", testNamespaceGetPodLogs),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,
@@ -217,7 +217,7 @@ func Test_GetPodLogs(t *testing.T) {
 		"ShouldNotStreamLogsWithInvalidContainerName": {
 			args: args{
 				token: "valid_token",
-				wsUrl: "/v1/logs/pod/" + testNamespaceGetPodLogs + "/" + pod1 + "?container=container" + testutils.NonExistentSuffix,
+				wsUrl: fmt.Sprintf("/v1/namespaces/%s/pod/%s/logs?container=container%s", testNamespaceGetPodLogs, pod1, testutils.NonExistentSuffix),
 			},
 			want: want{
 				statusCode:    http.StatusSwitchingProtocols,

--- a/src/routes/v1/namespace.go
+++ b/src/routes/v1/namespace.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"fmt"
 	"github.com/dana-team/platform-backend/src/customerrors"
-	"github.com/dana-team/platform-backend/src/routes"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
@@ -14,13 +14,13 @@ import (
 
 func namespaceHandler(handler func(controller controllers.NamespaceController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -28,7 +28,7 @@ func namespaceHandler(handler func(controller controllers.NamespaceController, c
 		namespaceController := controllers.NewNamespaceController(kubeClient, context, logger)
 
 		result, err := handler(namespaceController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -40,7 +40,7 @@ func GetNamespaces() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -54,7 +54,7 @@ func GetNamespace() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var namespaceUri types.NamespaceUri
 		if err := c.BindUri(&namespaceUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -68,7 +68,7 @@ func CreateNamespace() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var namespace types.Namespace
 		if err := c.BindJSON(&namespace); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -82,7 +82,7 @@ func DeleteNamespace() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var namespaceUri types.NamespaceUri
 		if err := c.BindUri(&namespaceUri); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/pods.go
+++ b/src/routes/v1/pods.go
@@ -2,9 +2,10 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/dana-team/platform-backend/src/routes"
 
 	"github.com/dana-team/platform-backend/src/controllers"
-	"github.com/dana-team/platform-backend/src/routes"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"github.com/gin-gonic/gin"
@@ -14,21 +15,21 @@ import (
 // podHandler wraps a handler function with context setup for PodController.
 func podHandler(handler func(controller controllers.PodController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		context := c.Request.Context()
+		context := routes.GetContext(c)
 		podController := controllers.NewPodController(kubeClient, context, logger)
 
 		result, err := handler(podController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -41,13 +42,13 @@ func GetPods() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request types.PodRequestUri
 		if err := c.BindUri(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/pods_test.go
+++ b/src/routes/v1/pods_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
@@ -74,16 +75,16 @@ func TestGetPods(t *testing.T) {
 				},
 			},
 		},
-		"ShouldNotGetPods": {
+		"ShouldNotGetPodsOnNotFoundCapp": {
 			args: args{
 				namespace: testNamespaceName,
 				cappName:  testutils.CappName + testutils.NonExistentSuffix,
 			},
 			want: want{
-				statusCode: http.StatusOK,
+				statusCode: http.StatusNotFound,
 				response: map[string]interface{}{
-					testutils.CountKey: 0,
-					testutils.PodsKey:  interface{}(nil),
+					testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName+testutils.NonExistentSuffix),
+					testutils.ReasonKey: testutils.ReasonNotFound,
 				},
 			},
 		},
@@ -93,10 +94,10 @@ func TestGetPods(t *testing.T) {
 				cappName:  testutils.CappName,
 			},
 			want: want{
-				statusCode: http.StatusOK,
+				statusCode: http.StatusNotFound,
 				response: map[string]interface{}{
-					testutils.CountKey: 0,
-					testutils.PodsKey:  interface{}(nil),
+					testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, testutils.CappName),
+					testutils.ReasonKey: testutils.ReasonNotFound,
 				},
 			},
 		},
@@ -104,6 +105,7 @@ func TestGetPods(t *testing.T) {
 
 	setup()
 	mocks.CreateTestNamespace(fakeClient, testNamespaceName)
+	mocks.CreateTestCapp(dynClient, testutils.CappName, testNamespaceName, testutils.Domain, map[string]string{}, map[string]string{})
 	mocks.CreateTestPod(fakeClient, testNamespaceName, pod1, testutils.CappName, false)
 	mocks.CreateTestPod(fakeClient, testNamespaceName, pod2, testutils.CappName, true)
 	mocks.CreateTestPod(fakeClient, testNamespaceName, pod3, "", false)

--- a/src/routes/v1/secret.go
+++ b/src/routes/v1/secret.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
-	"github.com/dana-team/platform-backend/src/routes"
+	"github.com/dana-team/platform-backend/src/middleware"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"net/http"
 
@@ -14,13 +14,13 @@ import (
 // secretHandler handles the request of the client to the Kubernetes cluster.
 func secretHandler(handler func(controller controllers.SecretController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -28,7 +28,7 @@ func secretHandler(handler func(controller controllers.SecretController, c *gin.
 		secretController := controllers.NewSecretController(kubeClient, context, logger)
 
 		result, err := handler(secretController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -41,12 +41,12 @@ func CreateSecret() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var uriRequest types.SecretNamespaceUriRequest
 		if err := c.BindUri(&uriRequest); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var request types.CreateSecretRequest
 		if err := c.BindJSON(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -61,13 +61,13 @@ func GetSecrets() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request types.SecretNamespaceUriRequest
 		if err := c.BindUri(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -82,7 +82,7 @@ func GetSecret() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request types.SecretUriRequest
 		if err := c.BindUri(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -97,12 +97,12 @@ func UpdateSecret() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var uriRequest types.SecretUriRequest
 		if err := c.BindUri(&uriRequest); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var request types.UpdateSecretRequest
 		if err := c.BindJSON(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -117,7 +117,7 @@ func DeleteSecret() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request types.SecretUriRequest
 		if err := c.BindUri(&request); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// SetupRoutes initializes the API routes for version 1.
 func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *runtime.Scheme) {
 	engine.Use(middleware.ErrorHandlingMiddleware())
 	v1 := engine.Group("/v1")
@@ -17,83 +18,146 @@ func SetupRoutes(engine *gin.Engine, tokenProvider auth.TokenProvider, scheme *r
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
+	setupAuthRoutes(v1, tokenProvider)
+	setupNamespaceRoutes(v1, tokenProvider, scheme)
+	setupClustersRoutes(v1, tokenProvider, scheme)
+}
+
+// setupAuthRoutes defines routes related to authentication.
+func setupAuthRoutes(v1 *gin.RouterGroup, tokenProvider auth.TokenProvider) {
 	authGroup := v1.Group("/login")
 	{
 		authGroup.POST("", Login(tokenProvider))
 	}
+}
 
-	logsGroup := v1.Group("/logs")
-	logsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
-	{
-		logsGroup.GET("/pod/:namespace/:cappName", GetPodLogs())
-		logsGroup.GET("/capp/:namespace/:cappName", GetCappLogs())
+// setupNamespaceRoutes defines routes related to namespaces and their resources.
+func setupNamespaceRoutes(v1 *gin.RouterGroup, tokenProvider auth.TokenProvider, scheme *runtime.Scheme) {
+	namespacesGroup := v1.Group("/namespaces")
 
+	if tokenProvider != nil {
+		namespacesGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	}
 
-	namespacesGroup := v1.Group("/namespaces")
-	namespacesGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
-		namespacesGroup.Use(middleware.PaginationMiddleware()).GET("", GetNamespaces())
+		getNamespaces := namespacesGroup.Group("")
+		getNamespaces.Use(middleware.PaginationMiddleware())
+		getNamespaces.GET("", GetNamespaces())
+
 		namespacesGroup.GET("/:namespaceName", GetNamespace())
 		namespacesGroup.POST("", CreateNamespace())
 		namespacesGroup.DELETE("/:namespaceName", DeleteNamespace())
 	}
 
 	secretsGroup := namespacesGroup.Group("/:namespaceName/secrets")
-	secretsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
+		getSecrets := secretsGroup.Group("")
+		getSecrets.Use(middleware.PaginationMiddleware())
+		getSecrets.GET("", GetSecrets())
+
 		secretsGroup.POST("", CreateSecret())
-		secretsGroup.Use(middleware.PaginationMiddleware()).GET("", GetSecrets())
 		secretsGroup.GET("/:secretName", GetSecret())
 		secretsGroup.PUT("/:secretName", UpdateSecret())
 		secretsGroup.DELETE("/:secretName", DeleteSecret())
 	}
 
 	cappGroup := namespacesGroup.Group("/:namespaceName/capps")
-	cappGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
+		getCapps := cappGroup.Group("")
+		getCapps.Use(middleware.PaginationMiddleware())
+		getCapps.GET("", GetCapps())
+
 		cappGroup.POST("", CreateCapp())
-		cappGroup.Use(middleware.PaginationMiddleware()).GET("", GetCapps())
 		cappGroup.GET("/:cappName", GetCapp())
 		cappGroup.PUT("/:cappName", UpdateCapp())
 		cappGroup.PUT("/:cappName/state", EditCappState())
 		cappGroup.GET("/:cappName/state", GetCappState())
-		cappGroup.GET("/:cappName/dns", GetCappDNS())
 		cappGroup.DELETE("/:cappName", DeleteCapp())
+
+		getDns := cappGroup.Group("")
+		getDns.Use(middleware.ClusterMiddleware())
+		getDns.GET("/:cappName/dns", GetCappDNS())
 	}
 
-	cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capprevisions")
-	cappRevisionGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
+	cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capps/:cappName/capprevisions")
+	cappRevisionGroup.Use(middleware.ClusterMiddleware())
 	{
-		cappRevisionGroup.Use(middleware.PaginationMiddleware()).GET("", GetCappRevisions())
+		getCappRevisions := cappRevisionGroup.Group("")
+		getCappRevisions.Use(middleware.PaginationMiddleware())
+		getCappRevisions.GET("", GetCappRevisions())
+
 		cappRevisionGroup.GET("/:cappRevisionName", GetCappRevision())
 	}
 
 	usersGroup := namespacesGroup.Group("/:namespaceName/users")
-	usersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
+		getUsers := usersGroup.Group("")
+		getUsers.Use(middleware.PaginationMiddleware())
+		getUsers.GET("", GetUsers())
+
 		usersGroup.POST("", CreateUser())
-		usersGroup.Use(middleware.PaginationMiddleware()).GET("", GetUsers())
 		usersGroup.GET("/:userName", GetUser())
 		usersGroup.PUT("/:userName", UpdateUser())
 		usersGroup.DELETE("/:userName", DeleteUser())
 	}
 
 	configMapGroup := namespacesGroup.Group("/:namespaceName/configmaps")
-	configMapGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
 	{
 		configMapGroup.GET("/:configMapName", GetConfigMap())
 	}
 
-	containersGroup := namespacesGroup.Group("/:namespaceName")
-	containersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
+	containersGroup := namespacesGroup.Group("/:namespaceName/pods/:podName/containers")
 	{
-		containersGroup.GET("/pods/:podName/containers", GetContainers())
+		containersGroup.GET("", GetPodsContainers())
 	}
 
-	podsGroup := namespacesGroup.Group("/:namespaceName")
-	podsGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
+	podsGroup := namespacesGroup.Group("/:namespaceName/capps/:cappName/pods")
+	podsGroup.Use(middleware.ClusterMiddleware())
 	{
-		podsGroup.Use(middleware.PaginationMiddleware()).GET("/capps/:cappName/pods", GetPods())
+		podsGroup.Use(middleware.PaginationMiddleware()).GET("", GetPods())
+	}
+
+	logsGroup := namespacesGroup.Group("/:namespaceName")
+	{
+		logsGroup.GET("/pod/:podName/logs", GetPodLogs())
+		logsGroup.GET("/capp/:cappName/logs", GetCappLogs()).Use(middleware.ClusterMiddleware())
+	}
+}
+
+// setupClustersRoutes defines routes related to clusters and their namespaces.
+func setupClustersRoutes(v1 *gin.RouterGroup, tokenProvider auth.TokenProvider, scheme *runtime.Scheme) {
+	clustersGroup := v1.Group("/clusters/:clusterName")
+	clustersGroup.Use(middleware.ClusterMiddleware())
+
+	if tokenProvider != nil {
+		clustersGroup.Use(middleware.TokenAuthMiddleware(tokenProvider, scheme))
+	}
+
+	namespacesGroup := clustersGroup.Group("/namespaces")
+	{
+		logsGroup := namespacesGroup.Group("/:namespaceName")
+		{
+			logsGroup.GET("/pod/:podName/logs", GetPodLogs())
+			logsGroup.GET("/capp/:cappName/logs", GetCappLogs())
+		}
+
+		cappRevisionGroup := namespacesGroup.Group("/:namespaceName/capprevisions")
+		{
+			getCappRevisions := cappRevisionGroup.Group("")
+			getCappRevisions.Use(middleware.PaginationMiddleware())
+			getCappRevisions.GET("", GetCappRevisions())
+
+			cappRevisionGroup.GET("/:cappRevisionName", GetCappRevision())
+		}
+
+		containersGroup := namespacesGroup.Group("/:namespaceName/pods/:podName/containers")
+		{
+			containersGroup.GET("", GetPodsContainers())
+		}
+
+		podsGroup := namespacesGroup.Group("/:namespaceName/capps/:cappName/pods")
+		{
+			podsGroup.GET("", GetPods()).Use(middleware.PaginationMiddleware())
+		}
 	}
 }

--- a/src/routes/v1/users.go
+++ b/src/routes/v1/users.go
@@ -2,9 +2,9 @@ package v1
 
 import (
 	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/middleware"
 
 	"github.com/dana-team/platform-backend/src/controllers"
-	"github.com/dana-team/platform-backend/src/routes"
 	"github.com/dana-team/platform-backend/src/types"
 	"github.com/dana-team/platform-backend/src/utils/pagination"
 	"github.com/gin-gonic/gin"
@@ -14,13 +14,13 @@ import (
 // usersHandler handles the request of the client to the Kubernetes cluster.
 func usersHandler(handler func(controller controllers.UserController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		kubeClient, err := routes.GetKubeClient(c)
-		if routes.AddErrorToContext(c, err) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
-		logger, err := routes.GetLogger(c)
-		if routes.AddErrorToContext(c, err) {
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -28,7 +28,7 @@ func usersHandler(handler func(controller controllers.UserController, c *gin.Con
 		userController := controllers.NewUserController(kubeClient, context, logger)
 
 		result, err := handler(userController, c)
-		if routes.AddErrorToContext(c, err) {
+		if middleware.AddErrorToContext(c, err) {
 			return
 		}
 
@@ -41,12 +41,12 @@ func CreateUser() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var namespace types.NamespaceUri
 		if err := c.BindUri(&namespace); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var user types.User
 		if err := c.BindJSON(&user); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -62,12 +62,12 @@ func UpdateUser() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var userIdentifier types.UserIdentifier
 		if err := c.BindUri(&userIdentifier); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 		var userRole types.UpdateUserData
 		if err := c.BindJSON(&userRole); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -83,13 +83,13 @@ func GetUsers() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var namespace types.NamespaceUri
 		if err := c.BindUri(&namespace); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
 		limit, page, err := pagination.ExtractPaginationParamsFromCtx(c)
 		if err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -104,7 +104,7 @@ func GetUser() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var userIdentifier types.UserIdentifier
 		if err := c.BindUri(&userIdentifier); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 
@@ -119,7 +119,7 @@ func DeleteUser() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var userIdentifier types.UserIdentifier
 		if err := c.BindUri(&userIdentifier); err != nil {
-			routes.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
 			return
 		}
 

--- a/src/types/capprevision.go
+++ b/src/types/capprevision.go
@@ -18,7 +18,9 @@ type CappRevisionList struct {
 }
 
 type CappRevisionNamespaceUri struct {
+	ClusterName   string `uri:"clusterName"`
 	NamespaceName string `uri:"namespaceName" binding:"required"`
+	CappName      string `uri:"cappName"`
 }
 
 type CappRevisionUri struct {

--- a/src/utils/labels.go
+++ b/src/utils/labels.go
@@ -14,6 +14,9 @@ var (
 	ParentCappLabel         = cappAPIGroup + "/parent-capp"
 	ParentCappNSLabel       = cappAPIGroup + "/parent-capp-ns"
 	ParentCappLabelSelector = ParentCappLabel + "=%s"
+
+	CappNameLabel         = cappAPIGroup + "/cappName"
+	CappNameLabelSelector = CappNameLabel + "=%s"
 )
 
 // AddManagedLabel adds the managed label to the given labels map.

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -3,11 +3,13 @@ package testutils
 import "time"
 
 const (
-	Domain       = "dana-team.io"
-	Hostname     = "custom-capp"
-	DefaultZone  = "dana-dev.com"
-	ManagedLabel = "rcs.dana.io/managed"
-	cappAPIGroup = "rcs.dana.io"
+	Domain         = "dana-team.io"
+	Hostname       = "custom-capp"
+	DefaultZone    = "dana-dev.com"
+	ManagedLabel   = "rcs.dana.io/managed"
+	ManagedByLabel = "rcs.dana.io/managed-by"
+	Rcs            = "rcs"
+	cappAPIGroup   = "rcs.dana.io"
 )
 
 const (
@@ -51,13 +53,19 @@ const (
 )
 
 const (
-	LabelSelectorKey     = "labelSelector"
-	LabelKey             = "key"
-	LabelValue           = "value"
-	InvalidLabelSelector = ":--"
-	LabelCappName        = "rcs.dana.io/cappName"
-	ParentCappLabel      = cappAPIGroup + "/parent-capp"
-	ParentCappNSLabel    = cappAPIGroup + "/parent-capp-ns"
+	LabelSelectorKey                = "labelSelector"
+	LabelKey                        = "key"
+	LabelValue                      = "value"
+	InvalidLabelSelector            = ":--"
+	LabelCappName                   = "rcs.dana.io/cappName"
+	ParentCappLabel                 = cappAPIGroup + "/parent-capp"
+	ParentCappNSLabel               = cappAPIGroup + "/parent-capp-ns"
+	LastUpdatedCappLabel            = cappAPIGroup + "/last-updated-by"
+	HasPlacementLabel               = cappAPIGroup + "/has-placement"
+	System                          = "system"
+	ServiceAccount                  = "serviceaccount"
+	RcsDeployerSystem               = "rcs-deployer-system"
+	RcsOcmDeployerControllerManager = "rcs-ocm-deployer-controller-manager"
 )
 
 const (

--- a/src/utils/testutils/mocks/capprevision.go
+++ b/src/utils/testutils/mocks/capprevision.go
@@ -2,34 +2,56 @@ package mocks
 
 import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	"github.com/dana-team/platform-backend/src/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PrepareCappRevision returns a mock CappRevision object.
 func PrepareCappRevision(name, namespace string, labels, annotations map[string]string) cappv1alpha1.CappRevision {
-	return cappv1alpha1.CappRevision{
+	cappRevision := cappv1alpha1.CappRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: annotations,
 			Labels:      labels,
 		},
-		Spec:   PrepareCappRevisionSpec(),
+		Spec:   PrepareCappRevisionSpec(labels, annotations),
 		Status: PrepareCappRevisionStatus(),
 	}
+
+	return cappRevision
 }
 
 // PrepareCappRevisionSpec returns a mock CappRevision Spec object.
-func PrepareCappRevisionSpec() cappv1alpha1.CappRevisionSpec {
-	return cappv1alpha1.CappRevisionSpec{
+func PrepareCappRevisionSpec(labels, annotations map[string]string) cappv1alpha1.CappRevisionSpec {
+	cappRevisionSpec := cappv1alpha1.CappRevisionSpec{
 		RevisionNumber: 1,
 		CappTemplate: cappv1alpha1.CappTemplate{
 			Spec: PrepareCappSpec(),
 		},
 	}
+
+	if annotations != nil {
+		cappRevisionSpec.CappTemplate.Annotations = annotations
+	}
+
+	if labels != nil {
+		cappRevisionSpec.CappTemplate.Labels = labels
+	}
+
+	return cappRevisionSpec
 }
 
 // PrepareCappRevisionStatus returns a mock CappRevision Status object.
 func PrepareCappRevisionStatus() cappv1alpha1.CappRevisionStatus {
 	return cappv1alpha1.CappRevisionStatus{}
+}
+
+func ConvertKeyValueSliceToMap(keyValueSlice []types.KeyValue) map[string]string {
+	keyValueMap := make(map[string]string)
+	for _, kv := range keyValueSlice {
+		keyValueMap[kv.Key] = kv.Value
+	}
+
+	return keyValueMap
 }

--- a/test/e2e_tests/capp.go
+++ b/test/e2e_tests/capp.go
@@ -4,22 +4,27 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"net/url"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/controllers"
 	"github.com/dana-team/platform-backend/src/types"
-	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 )
+
+func getCappClusterDomain(site string) string {
+	return fmt.Sprintf("apps.%s.os-pub.com", site)
+}
 
 var _ = Describe("Validate Capp routes and functionality", func() {
 	var namespaceName, oneCappName, secondCappName string
 	var oneLabelKey, oneLabelValue, secondLabelKey, secondLabelValue string
+	var oneCappSite, secondCappSite string
 
 	BeforeEach(func() {
 		namespaceName = generateName(e2eNamespace)
@@ -28,12 +33,14 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 		oneCappName = generateName("a-" + testCappName)
 		oneLabelKey = generateName(e2eLabelKey)
 		oneLabelValue = generateName(e2eLabelValue)
-		createTestCapp(k8sClient, oneCappName, namespaceName, map[string]string{oneLabelKey: oneLabelValue}, nil)
+		oneCapp := createTestCapp(k8sClient, oneCappName, namespaceName, map[string]string{oneLabelKey: oneLabelValue}, nil)
+		oneCappSite = oneCapp.Status.ApplicationLinks.Site
 
 		secondCappName = generateName("b-" + testCappName)
 		secondLabelKey = generateName(e2eLabelKey)
 		secondLabelValue = generateName(e2eLabelValue)
-		createTestCapp(k8sClient, secondCappName, namespaceName, map[string]string{secondLabelKey: secondLabelValue}, nil)
+		secondCapp := createTestCapp(k8sClient, secondCappName, namespaceName, map[string]string{secondLabelKey: secondLabelValue}, nil)
+		secondCappSite = secondCapp.Status.ApplicationLinks.Site
 	})
 
 	Context("Validate get Capps route", func() {
@@ -43,8 +50,8 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
-					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, clusterDomain)},
-					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, getCappClusterDomain(oneCappSite))},
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, getCappClusterDomain(secondCappSite))},
 				},
 				testutils.CountKey: 2,
 			}
@@ -62,8 +69,8 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
-					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, clusterDomain)},
-					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, getCappClusterDomain(oneCappSite))},
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, getCappClusterDomain(secondCappSite))},
 				},
 				testutils.CountKey: 2,
 			}
@@ -81,7 +88,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
-					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, clusterDomain)},
+					{Name: oneCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", oneCappName, namespaceName, getCappClusterDomain(oneCappSite))},
 				},
 				testutils.CountKey: 1,
 			}
@@ -99,7 +106,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
-					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, getCappClusterDomain(secondCappSite))},
 				},
 				testutils.CountKey: 1,
 			}
@@ -133,7 +140,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 
 			expectedResponse := map[string]interface{}{
 				testutils.CappsKey: []types.CappSummary{
-					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, clusterDomain)},
+					{Name: secondCappName, Images: []string{CappImageName}, URL: fmt.Sprintf("https://%s-%s.%s", secondCappName, namespaceName, getCappClusterDomain(secondCappSite))},
 				},
 				testutils.CountKey: 1,
 			}
@@ -236,7 +243,7 @@ var _ = Describe("Validate Capp routes and functionality", func() {
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey:    types.Metadata{Name: newCappName, Namespace: namespaceName},
 				testutils.LabelsKey:      []types.KeyValue{{Key: testutils.LabelKey, Value: testutils.LabelValue}},
-				testutils.AnnotationsKey: nil,
+				testutils.AnnotationsKey: []types.KeyValue{{Key: testutils.LastUpdatedCappLabel, Value: e2eUser}},
 				testutils.SpecKey:        mocks.PrepareCappSpec(),
 				testutils.StatusKey:      cappv1alpha1.CappStatus{},
 			}

--- a/test/e2e_tests/capprevision.go
+++ b/test/e2e_tests/capprevision.go
@@ -10,49 +10,50 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"net/http"
-	"net/url"
 )
 
 var _ = Describe("Validate CappRevision routes and functionality", func() {
 	var namespaceName, oneCappName, secondCappName string
 	var oneCappRevisionNames, secondCappRevisionNames []string
+	var site string
 
 	BeforeEach(func() {
 		namespaceName = generateName(e2eNamespace)
 		createTestNamespace(k8sClient, namespaceName)
 
 		oneCappName = generateName("a-" + testCappRevisionName)
-		createTestCapp(k8sClient, oneCappName, namespaceName, nil, nil)
-		oneCappRevisionNames = getCappRevisionNames(k8sClient, oneCappName, namespaceName)
+		oneCapp := createTestCapp(k8sClient, oneCappName, namespaceName, nil, nil)
+		oneCappRevisionNames = getCappRevisionNames(k8sClient, oneCappName, namespaceName, oneCapp.Status.ApplicationLinks.Site)
 
 		secondCappName = generateName("b-" + testCappRevisionName)
-		createTestCapp(k8sClient, secondCappName, namespaceName, nil, nil)
-		secondCappRevisionNames = getCappRevisionNames(k8sClient, secondCappName, namespaceName)
+		secondCapp := createTestCapp(k8sClient, secondCappName, namespaceName, nil, nil)
+		secondCappRevisionNames = getCappRevisionNames(k8sClient, secondCappName, namespaceName, secondCapp.Status.ApplicationLinks.Site)
+
+		site = oneCapp.Status.ApplicationLinks.Site
 	})
 
-	Context("Validate get CappRevisions route", func() {
-
-		It("Should get all CappRevisions in a namespace with limit of 50", func() {
+	Context("Validate get CappRevisions from Capp route", func() {
+		It("Should get all CappRevisions of a specific capp in a namespace with limit of 50", func() {
 			limit := "50"
 			page := "1"
 
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s?limit=%s&page=%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, limit, page)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
-				testutils.CapprevisionsKey: append(oneCappRevisionNames, secondCappRevisionNames...),
-				testutils.CountKey:         2,
+				testutils.CapprevisionsKey: oneCappRevisionNames,
+				testutils.CountKey:         len(oneCappRevisionNames),
 			}
 
 			Expect(status).Should(Equal(http.StatusOK))
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should get one CappRevisions in a namespace with limit of 1 and page 1", func() {
+		It("Should get one CappRevision of a specific capp in a namespace with limit of 1 and page 1", func() {
 			limit := "1"
 			page := "1"
 
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s?limit=%s&page=%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, limit, page)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
@@ -64,16 +65,16 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should get one CappRevisions in a namespace with limit of 1 and page 2", func() {
+		It("Should not get CappRevisions in a namespace with limit of 1 and page 2", func() {
 			limit := "1"
 			page := "2"
 
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s?limit=%s&page=%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, limit, page)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
-				testutils.CapprevisionsKey: secondCappRevisionNames,
-				testutils.CountKey:         1,
+				testutils.CapprevisionsKey: nil,
+				testutils.CountKey:         0,
 			}
 
 			Expect(status).Should(Equal(http.StatusOK))
@@ -83,11 +84,11 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should not get CappRevisions with limit of 1 and page 10000", func() {
+		It("Should not get CappRevisions of a specific capp with limit of 1 and page 10000", func() {
 			limit := "1"
 			page := "10000"
 
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s?limit=%s&page=%s", platformURL, namespaceName, testutils.CapprevisionsKey, limit, page)
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s?limit=%s&page=%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, limit, page)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
@@ -99,28 +100,144 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should get all CappRevisions in a namespace", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
+		It("Should get all CappRevisions of a specific capp in a namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s", platformURL, namespaceName, secondCappName, testutils.CapprevisionsKey)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
-				testutils.CapprevisionsKey: append(oneCappRevisionNames, secondCappRevisionNames...),
-				testutils.CountKey:         2,
+				testutils.CapprevisionsKey: secondCappRevisionNames,
+				testutils.CountKey:         len(secondCappRevisionNames),
 			}
 
 			Expect(status).Should(Equal(http.StatusOK))
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should get all CappRevisions with a specific labelSelector in a namespace", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
-			params := url.Values{}
-			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", testutils.LabelCappName, secondCappName))
-
-			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+		It("Should fail getting CappRevisions with an invalid capp name", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s", platformURL, namespaceName, oneCappName+testutils.NonExistentSuffix, testutils.CapprevisionsKey)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
-				testutils.CapprevisionsKey: secondCappRevisionNames,
+				testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+	})
+
+	Context("Validate get CappRevision from Capp route", func() {
+		It("Should get a specific CappRevision in a namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s/%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, oneCappRevisionNames[0])
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			annotations := []types.KeyValue{
+				{Key: testutils.HasPlacementLabel, Value: site},
+				{Key: testutils.LastUpdatedCappLabel, Value: fmt.Sprintf("%s:%s:%s:%s", testutils.System, testutils.ServiceAccount, testutils.RcsDeployerSystem, testutils.RcsOcmDeployerControllerManager)}}
+
+			expectedResponse := map[string]interface{}{
+				testutils.MetadataKey:    types.Metadata{Name: oneCappRevisionNames[0], Namespace: namespaceName},
+				testutils.AnnotationsKey: annotations,
+				testutils.LabelsKey:      []types.KeyValue{{Key: testutils.LabelCappName, Value: oneCappName}},
+				testutils.SpecKey: mocks.PrepareCappRevisionSpec(
+					mocks.ConvertKeyValueSliceToMap([]types.KeyValue{{Key: testutils.ManagedByLabel, Value: testutils.Rcs}}),
+					mocks.ConvertKeyValueSliceToMap(annotations)),
+				testutils.StatusKey: mocks.PrepareCappRevisionStatus(),
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a not found CappRevision in a namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s/%s", platformURL, namespaceName, oneCappName, testutils.CapprevisionsKey, oneCappName+testutils.NonExistentSuffix)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey: fmt.Sprintf("%s, %s",
+					fmt.Sprintf(controllers.ErrCouldNotGetCappRevision, oneCappName+testutils.NonExistentSuffix, namespaceName),
+					fmt.Sprintf("%s.%s %q not found", testutils.CapprevisionsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
+				),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			cappRevision := mocks.PrepareCappRevision(oneCappName+testutils.NonExistentSuffix, namespaceName, nil, nil)
+			Expect(doesResourceExist(k8sClient, &cappRevision)).To(BeFalse())
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a get of a CappRevision in a not found namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/capps/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, oneCappName, testutils.CapprevisionsKey, oneCappName)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CappsKey, cappv1alpha1.GroupVersion.Group, oneCappName),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			cappRevision := mocks.PrepareCappRevision(oneCappName, namespaceName+testutils.NonExistentSuffix, nil, nil)
+			Expect(doesResourceExist(k8sClient, &cappRevision)).To(BeFalse())
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+	})
+
+	Context("Validate get CappRevisions from cluster route", func() {
+		It("Should get all CappRevisions in a cluster", func() {
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s", platformURL, site, namespaceName, testutils.CapprevisionsKey)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			allCapps := append(oneCappRevisionNames, secondCappRevisionNames...)
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: allCapps,
+				testutils.CountKey:         len(allCapps),
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should fail getting CappRevisions with an invalid cluster", func() {
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s", platformURL, site+testutils.NonExistentSuffix, namespaceName, testutils.CapprevisionsKey)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf("Could not list capp revisions, no such cluster %s", site+testutils.NonExistentSuffix),
+				testutils.ReasonKey: "",
+			}
+
+			Expect(status).Should(Equal(http.StatusInternalServerError))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get all CappRevisions in a namespace with limit of 50", func() {
+			limit := "50"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s?limit=%s&page=%s", platformURL, site, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			allCapps := append(oneCappRevisionNames, secondCappRevisionNames...)
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: allCapps,
+				testutils.CountKey:         len(allCapps),
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should get one CappRevision in a namespace with limit of 1 and page 1", func() {
+			limit := "1"
+			page := "1"
+
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s?limit=%s&page=%s", platformURL, site, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.CapprevisionsKey: oneCappRevisionNames,
 				testutils.CountKey:         1,
 			}
 
@@ -128,28 +245,12 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 			compareResponses(response, expectedResponse)
 		})
 
-		It("Should fail getting CappRevisions with an invalid labelSelector", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
-			params := url.Values{}
-			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s", testutils.LabelCappName, testutils.InvalidLabelSelector))
+		It("Should not get CappRevisions with limit of 1 and page 10000", func() {
+			limit := "1"
+			page := "10000"
 
-			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
-
-			expectedResponse := map[string]interface{}{
-				testutils.ErrorKey:  controllers.ErrParsingLabelSelector,
-				testutils.ReasonKey: testutils.ReasonBadRequest,
-			}
-
-			Expect(status).Should(Equal(http.StatusBadRequest))
-			compareResponses(response, expectedResponse)
-		})
-
-		It("Should get no CappRevisions with valid labelSelector", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey)
-			params := url.Values{}
-			params.Add(testutils.LabelSelectorKey, fmt.Sprintf("%s=%s%s", testutils.LabelCappName, secondCappName, testutils.NonExistentSuffix))
-
-			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, fmt.Sprintf("%s?%s", uri, params.Encode()), "", "", userToken)
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s?limit=%s&page=%s", platformURL, site, namespaceName, testutils.CapprevisionsKey, limit, page)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
 				testutils.CapprevisionsKey: nil,
@@ -161,17 +262,23 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 		})
 	})
 
-	Context("Validate get CappRevision route", func() {
+	Context("Validate get CappRevision from cluster route", func() {
 		It("Should get a specific CappRevision in a namespace", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey, oneCappRevisionNames[0])
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s/%s", platformURL, site, namespaceName, testutils.CapprevisionsKey, oneCappRevisionNames[0])
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
+
+			annotations := []types.KeyValue{
+				{Key: testutils.HasPlacementLabel, Value: site},
+				{Key: testutils.LastUpdatedCappLabel, Value: fmt.Sprintf("%s:%s:%s:%s", testutils.System, testutils.ServiceAccount, testutils.RcsDeployerSystem, testutils.RcsOcmDeployerControllerManager)}}
 
 			expectedResponse := map[string]interface{}{
 				testutils.MetadataKey:    types.Metadata{Name: oneCappRevisionNames[0], Namespace: namespaceName},
-				testutils.AnnotationsKey: nil,
+				testutils.AnnotationsKey: annotations,
 				testutils.LabelsKey:      []types.KeyValue{{Key: testutils.LabelCappName, Value: oneCappName}},
-				testutils.SpecKey:        mocks.PrepareCappRevisionSpec(),
-				testutils.StatusKey:      mocks.PrepareCappRevisionStatus(),
+				testutils.SpecKey: mocks.PrepareCappRevisionSpec(
+					mocks.ConvertKeyValueSliceToMap([]types.KeyValue{{Key: testutils.ManagedByLabel, Value: testutils.Rcs}}),
+					mocks.ConvertKeyValueSliceToMap(annotations)),
+				testutils.StatusKey: mocks.PrepareCappRevisionStatus(),
 			}
 
 			Expect(status).Should(Equal(http.StatusOK))
@@ -179,11 +286,14 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 		})
 
 		It("Should handle a not found CappRevision in a namespace", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName, testutils.CapprevisionsKey, oneCappName+testutils.NonExistentSuffix)
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s/%s", platformURL, site, namespaceName, testutils.CapprevisionsKey, oneCappName+testutils.NonExistentSuffix)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{
-				testutils.ErrorKey:  fmt.Sprintf("%s.%s %q not found", testutils.CapprevisionsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
+				testutils.ErrorKey: fmt.Sprintf("%s, %s",
+					fmt.Sprintf(controllers.ErrCouldNotGetCappRevision, oneCappName+testutils.NonExistentSuffix, namespaceName),
+					fmt.Sprintf("%s.%s %q not found", testutils.CapprevisionsKey, cappv1alpha1.GroupVersion.Group, oneCappName+testutils.NonExistentSuffix),
+				),
 				testutils.ReasonKey: testutils.ReasonNotFound,
 			}
 
@@ -194,7 +304,7 @@ var _ = Describe("Validate CappRevision routes and functionality", func() {
 		})
 
 		It("Should handle a get of a CappRevision in a not found namespace", func() {
-			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s", platformURL, namespaceName+testutils.NonExistentSuffix, testutils.CapprevisionsKey, oneCappName)
+			uri := fmt.Sprintf("%s/v1/clusters/%s/namespaces/%s/%s/%s", platformURL, site, namespaceName+testutils.NonExistentSuffix, testutils.CapprevisionsKey, oneCappName)
 			status, response := performHTTPRequest(httpClient, nil, http.MethodGet, uri, "", "", userToken)
 
 			expectedResponse := map[string]interface{}{

--- a/test/e2e_tests/resources.go
+++ b/test/e2e_tests/resources.go
@@ -5,6 +5,7 @@ import (
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	multicluster "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/transport"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -78,6 +79,11 @@ func createCapp(k8sClient client.Client, capp *cappv1alpha1.Capp) *cappv1alpha1.
 	Eventually(func() string {
 		return getCapp(k8sClient, newCapp.Name, newCapp.Namespace).Status.KnativeObjectStatus.ConfigurationStatusFields.LatestReadyRevisionName
 	}, testutils.Timeout, testutils.Interval).ShouldNot(Equal(""))
+
+	Eventually(func() string {
+		newCapp = getCapp(k8sClient, newCapp.Name, newCapp.Namespace)
+		return newCapp.Status.ApplicationLinks.Site
+	}, testutils.Timeout, testutils.Interval).ShouldNot(Equal(""), "missing site in capp status")
 	return newCapp
 }
 
@@ -103,15 +109,16 @@ func getCapp(k8sClient client.Client, name string, namespace string) *cappv1alph
 }
 
 // getCappRevisionNames returns a list of the CappRevision names related to a specific Capp in a namespace.
-func getCappRevisionNames(k8sClient client.Client, cappName string, namespace string) []string {
+func getCappRevisionNames(k8sClient client.Client, cappName, namespace, clusterName string) []string {
 	revisions := cappv1alpha1.CappRevisionList{}
 	labelSelector := client.MatchingLabels{testutils.LabelCappName: cappName}
 	listOptions := []client.ListOption{
 		labelSelector,
 		client.InNamespace(namespace),
 	}
-
 	Expect(k8sClient.List(context.TODO(), &revisions, listOptions...)).To(Succeed())
+
+	Expect(k8sClient.List(multicluster.WithMultiClusterContext(context.TODO(), clusterName), &revisions, listOptions...)).To(Succeed())
 
 	names := make([]string, len(revisions.Items))
 	for i, revision := range revisions.Items {
@@ -165,9 +172,9 @@ func createTestNamespace(k8sClient client.Client, name string) {
 }
 
 // createTestCapp creates a test Capp object.
-func createTestCapp(k8sClient client.Client, name, namespace string, labels, annotations map[string]string) {
+func createTestCapp(k8sClient client.Client, name, namespace string, labels, annotations map[string]string) *cappv1alpha1.Capp {
 	capp := mocks.PrepareCapp(name, namespace, clusterDomain, labels, annotations)
-	createCapp(k8sClient, &capp)
+	return createCapp(k8sClient, &capp)
 }
 
 // createTestCapp creates a test Capp object.

--- a/test/e2e_tests/suite_test.go
+++ b/test/e2e_tests/suite_test.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	multicluster "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/transport"
 	"net/http"
-	"strings"
 	"testing"
 
-	"github.com/dana-team/platform-backend/src/utils/testutils"
 	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -108,6 +108,7 @@ func initKubeClient() {
 	cfg, err := config.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
 
+	cfg.Wrap(multicluster.NewClusterGatewayRoundTripper)
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
@@ -200,15 +201,9 @@ func getTokenFromLogin() {
 
 // getClusterIngressDomain returns the ingress domain of an OpenShift cluster.
 func getClusterIngressDomain() {
-	if platformURL == "" {
-		ingress := &configv1.Ingress{}
-		getClusterResource(k8sClient, ingress, clusterIngressName)
-		clusterDomain = ingress.Spec.Domain
-		return
-	}
-
-	urlSplit := strings.Split(platformURL, ".")
-	clusterDomain = strings.Join(urlSplit[1:], ".")
+	ingress := &configv1.Ingress{}
+	getClusterResource(k8sClient, ingress, clusterIngressName)
+	clusterDomain = ingress.Spec.Domain
 }
 
 // cleanUpTestNamespaces deletes test namespaces.


### PR DESCRIPTION
This PR introduces multi-cluster support. 

## Changes
* Multi-Cluster Support: enable routing across different clusters.
* New Clusters Routes: Defined under `/clusters/:clusterName/namespaces/:namespaceName`,  providing access to:
    * Logs
    * Containers
    * Pods