### PR TITLE
fix: fix logs route to use multi cluster

### DIFF
--- a/src/routes/v1/logs_stream_test.go
+++ b/src/routes/v1/logs_stream_test.go
@@ -54,7 +54,7 @@ func Test_GetCappLogs(t *testing.T) {
 				wsUrl: fmt.Sprintf("/v1/namespaces/%s/capp/invalid-capp/logs", testNamespaceGetCappLogs),
 			},
 			want: want{
-				statusCode:    http.StatusSwitchingProtocols,
+				statusCode:    http.StatusNotFound,
 				expectedLines: []string{fmt.Sprintf("error: Error streaming %q logs: no pods found for Capp %q in namespace %q", "Capp", "invalid-capp", testNamespaceGetCappLogs)},
 			},
 		},
@@ -112,6 +112,7 @@ func Test_GetCappLogs(t *testing.T) {
 
 	setup()
 	mocks.CreateTestNamespace(fakeClient, testNamespaceGetCappLogs)
+	mocks.CreateTestCapp(dynClient, testutils.CappName, testNamespaceGetCappLogs, testutils.Domain, testutils.SiteName, map[string]string{}, nil)
 	mocks.CreateTestPod(fakeClient, testNamespaceGetCappLogs, pod1, "", false)
 	mocks.CreateTestPod(fakeClient, testNamespaceGetCappLogs, pod2, testutils.CappName, true)
 
@@ -130,7 +131,7 @@ func Test_GetCappLogs(t *testing.T) {
 
 			conn, resp, err := dialer.Dial(wsURL, headers)
 			assert.Equal(t, tc.want.statusCode, resp.StatusCode)
-			if tc.want.statusCode == http.StatusUnauthorized {
+			if tc.want.statusCode == http.StatusUnauthorized || tc.want.statusCode == http.StatusNotFound {
 				return
 			}
 

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -120,7 +120,7 @@ func setupNamespaceRoutes(v1 *gin.RouterGroup, tokenProvider auth.TokenProvider,
 	logsGroup := namespacesGroup.Group("/:namespaceName")
 	{
 		logsGroup.GET("/pod/:podName/logs", GetPodLogs())
-		logsGroup.GET("/capp/:cappName/logs", GetCappLogs()).Use(middleware.ClusterMiddleware())
+		logsGroup.Use(middleware.ClusterMiddleware()).GET("/capp/:cappName/logs", GetCappLogs())
 	}
 
 	serviceAccountsGroup := namespacesGroup.Group("/:namespaceName/serviceaccounts")
@@ -162,7 +162,7 @@ func setupClustersRoutes(v1 *gin.RouterGroup, tokenProvider auth.TokenProvider, 
 
 		podsGroup := namespacesGroup.Group("/:namespaceName/capps/:cappName/pods")
 		{
-			podsGroup.GET("", GetPods()).Use(middleware.PaginationMiddleware())
+			podsGroup.Use(middleware.PaginationMiddleware()).GET("", GetPods())
 		}
 	}
 }


### PR DESCRIPTION
## Description
This update refactors two route definitions by chaining middleware before the route handlers. 
This ensures that middleware is applied right before the corresponding route handlers. 
