### PR TITLE
feat: create and revoke tokens for ServiceAccounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/go-playground/validator/v10 v10.22.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBExVwjEviJTixqxL8=
-github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/validator/v10 v10.22.1 h1:40JcKH+bBNGFczGuoBYgX4I6m/i27HYW8P9FDk5PbgA=
+github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=

--- a/src/controllers/serviceaccounts.go
+++ b/src/controllers/serviceaccounts.go
@@ -145,6 +145,7 @@ func (c *serviceAccountController) CreateServiceAccount(name, namespace string) 
 	if err != nil {
 		return types.ServiceAccount{}, customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotCreateServiceAccount, name, namespace), err)
 	}
+
 	return types.ServiceAccount{Name: name}, nil
 }
 

--- a/src/controllers/setup_test.go
+++ b/src/controllers/setup_test.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	dnsrecordv1alpha1 "github.com/dana-team/provider-dns/apis/record/v1alpha1"
 	"go.uber.org/zap"
@@ -12,10 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-	"os"
+
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 var (

--- a/src/controllers/tokens.go
+++ b/src/controllers/tokens.go
@@ -1,0 +1,198 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/dana-team/platform-backend/src/types"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/utils"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	secretKind         = "Secret"
+	tokenRequestSuffix = "token-request"
+	serviceAccountKind = "ServiceAccount"
+	defaultExpiration  = "36000"
+)
+
+const (
+	ErrCouldNotCreateTokenRequestSecret = "Could not create token request secret for serviceaccount %q in namespace %q"
+	ErrCouldNotGetTokenRequestSecret    = "Could not get token request secret for serviceaccount %q in namespace %q"
+	ErrCouldNotDeleteTokenRequestSecret = "Could not delete token request secret for serviceaccount %q in namespace %q"
+	ErrCouldNotCreateTokenRequest       = "Could not create token request for serviceaccount %q in namespace %q"
+	ErrInvalidExpirationSeconds         = "Invalid expiration seconds: %s"
+)
+
+type tokenController struct {
+	client kubernetes.Interface
+	ctx    context.Context
+	logger *zap.Logger
+}
+
+type TokenController interface {
+	// RevokeToken revokes a token by name of the serviceaccount.
+	RevokeToken(serviceAccountName, namespace string) error
+
+	// CreateToken creates a token for a serviceaccount.
+	CreateToken(serviceAccountName, namespace string, expirationSeconds string) (types.TokenRequestResponse, error)
+}
+
+// NewTokenController creates a new token controller.
+func NewTokenController(client kubernetes.Interface, ctx context.Context, logger *zap.Logger) TokenController {
+	return &tokenController{
+		client: client,
+		ctx:    ctx,
+		logger: logger,
+	}
+}
+
+func (t *tokenController) RevokeToken(serviceAccountName, namespace string) error {
+	serviceAccount, err := t.client.CoreV1().ServiceAccounts(namespace).Get(t.ctx, serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetServiceAccount, serviceAccountName, namespace), err.Error()))
+		return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetServiceAccount, serviceAccountName, namespace), err)
+	}
+
+	_, err = t.client.CoreV1().Secrets(namespace).Get(t.ctx, fmt.Sprintf("%s-%s", serviceAccount.Name, tokenRequestSuffix), metav1.GetOptions{})
+	if err != nil {
+		t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err.Error()))
+		return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err)
+	}
+	if err = DeleteTokenRequestSecret(t.ctx, t.client, serviceAccountName, namespace); err != nil {
+		t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotDeleteTokenRequestSecret, serviceAccountName, namespace), err.Error()))
+		return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotDeleteTokenRequestSecret, serviceAccountName, namespace), err)
+	}
+	return nil
+}
+
+func (t *tokenController) CreateToken(serviceAccountName, namespace string, expirationSeconds string) (types.TokenRequestResponse, error) {
+	tokenRequestSecret, err := t.client.CoreV1().Secrets(namespace).Get(t.ctx, fmt.Sprintf("%s-%s", serviceAccountName, tokenRequestSuffix), metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if createTokenErr := CreateTokenRequestSecret(t.ctx, t.client, serviceAccountName, namespace, t.logger); createTokenErr != nil {
+				t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotCreateTokenRequestSecret, serviceAccountName, namespace), createTokenErr.Error()))
+				return types.TokenRequestResponse{}, customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotCreateTokenRequestSecret, serviceAccountName, namespace), createTokenErr)
+			}
+		} else {
+			t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err.Error()))
+			return types.TokenRequestResponse{}, customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err)
+		}
+	}
+	expireIn, err := getExpirationSeconds(expirationSeconds)
+	if err != nil {
+		t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotCreateTokenRequest, serviceAccountName, namespace), err.Error()))
+		return types.TokenRequestResponse{}, customerrors.NewValidationError(err.Error())
+	}
+
+	tokenRequest := prepareTokenRequest(serviceAccountName, namespace, tokenRequestSecret, expireIn)
+
+	createdRequest, err := t.client.CoreV1().ServiceAccounts(namespace).CreateToken(t.ctx, serviceAccountName, tokenRequest, metav1.CreateOptions{})
+	if err != nil {
+		t.logger.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotCreateTokenRequest, serviceAccountName, namespace), err.Error()))
+		return types.TokenRequestResponse{}, customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotCreateTokenRequest, serviceAccountName, namespace), err)
+	}
+	return types.TokenRequestResponse{Token: createdRequest.Status.Token, Expires: createdRequest.Status.ExpirationTimestamp.Time}, nil
+}
+
+// CreateTokenRequestSecret creates a secret for the token request.
+// All token requests for a service account are bound to this secret.
+// When this secret is deleted, all tokens bound to it are revoked.
+func CreateTokenRequestSecret(ctx context.Context, client kubernetes.Interface, serviceAccountName, namespace string, log *zap.Logger) error {
+	_, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("%s-%s", serviceAccountName, tokenRequestSuffix), metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err.Error()))
+			return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetTokenRequestSecret, serviceAccountName, namespace), err)
+		}
+	}
+	serviceAccount, err := client.CoreV1().ServiceAccounts(namespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		log.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotGetServiceAccount, serviceAccountName, namespace), err.Error()))
+		return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotGetServiceAccount, serviceAccountName, namespace), err)
+	}
+	serviceAccountSecret := prepareTokenRequestSecret(serviceAccount)
+	_, err = client.CoreV1().Secrets(namespace).Create(ctx, serviceAccountSecret, metav1.CreateOptions{})
+	if err != nil {
+		log.Error(fmt.Sprintf("%s with error: %s", fmt.Sprintf(ErrCouldNotCreateTokenRequestSecret, serviceAccountName, namespace), err.Error()))
+		return customerrors.NewAPIError(fmt.Sprintf(ErrCouldNotCreateTokenRequestSecret, serviceAccountName, namespace), err)
+	}
+	return nil
+}
+
+// DeleteTokenRequestSecret deletes the secret for token requests.
+func DeleteTokenRequestSecret(ctx context.Context, client kubernetes.Interface, serviceAccountName, namespace string) error {
+	err := client.CoreV1().Secrets(namespace).Delete(ctx, fmt.Sprintf("%s-%s", serviceAccountName, tokenRequestSuffix), metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// getExpirationSeconds returns the expiration seconds for a token as a pointer.
+func getExpirationSeconds(expirationSeconds string) (*int64, error) {
+	if expirationSeconds == "" {
+		expirationSeconds = defaultExpiration
+	}
+	expireIn, err := strconv.Atoi(expirationSeconds)
+	if err != nil {
+		return nil, errors.NewBadRequest(fmt.Sprintf(ErrInvalidExpirationSeconds, expirationSeconds))
+	}
+	seconds := new(int64)
+	*seconds = int64(expireIn)
+	return seconds, nil
+}
+
+// prepareTokenRequest creates a token request object.
+func prepareTokenRequest(name, namespace string, tokenRequestSecret *corev1.Secret, expirationSeconds *int64) *authenticationv1.TokenRequest {
+	return &authenticationv1.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: authenticationv1.TokenRequestSpec{
+			BoundObjectRef: &authenticationv1.BoundObjectReference{
+				Kind:       secretKind,
+				Name:       tokenRequestSecret.Name,
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				UID:        tokenRequestSecret.UID,
+			},
+			ExpirationSeconds: expirationSeconds,
+		},
+	}
+}
+
+// prepareTokenRequestSecret creates a secret for the token requests.
+func prepareTokenRequestSecret(serviceAccount *corev1.ServiceAccount) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", serviceAccount.Name, tokenRequestSuffix),
+			Namespace: serviceAccount.Namespace,
+			Labels: map[string]string{
+				utils.ManagedLabel: utils.ManagedLabelValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       serviceAccountKind,
+					Name:       serviceAccount.Name,
+					UID:        serviceAccount.UID,
+				},
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}

--- a/src/controllers/tokens_test.go
+++ b/src/controllers/tokens_test.go
@@ -1,0 +1,164 @@
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dana-team/platform-backend/src/types"
+
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/utils"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateToken(t *testing.T) {
+	namespaceName := testutils.TokenNamespace + "-create-token"
+	type requestParams struct {
+		name                 string
+		namespace            string
+		createServiceAccount bool
+		expiration           string
+	}
+	type want struct {
+		response    types.TokenRequestResponse
+		errorStatus metav1.StatusReason
+	}
+	cases := map[string]struct {
+		request requestParams
+		want    want
+	}{
+		"ShouldSucceedCreatingToken": {
+			request: requestParams{
+				name:                 testutils.ServiceAccountName,
+				namespace:            namespaceName,
+				createServiceAccount: true,
+				expiration:           "3600",
+			},
+			want: want{
+				response:    types.TokenRequestResponse{Token: ""},
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFailCreatingTokenWithoutServiceAccount": {
+			request: requestParams{
+				name:                 testutils.ServiceAccountName + testutils.NonExistentSuffix,
+				namespace:            namespaceName,
+				createServiceAccount: false,
+				expiration:           "3600",
+			},
+			want: want{
+				response:    types.TokenRequestResponse{Token: ""},
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+		"ShouldFailCreatingTokenWithInvalidExpiration": {
+			request: requestParams{
+				name:                 testutils.ServiceAccountName + "-invalid-expiration",
+				namespace:            namespaceName,
+				createServiceAccount: true,
+				expiration:           testutils.TestName,
+			},
+			want: want{
+				response:    types.TokenRequestResponse{Token: ""},
+				errorStatus: metav1.StatusReasonBadRequest,
+			},
+		},
+	}
+	setup()
+	tokenController := NewTokenController(fakeClient, mocks.GinContext(), logger)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.request.createServiceAccount {
+				mocks.CreateTestServiceAccount(fakeClient, tc.request.namespace, tc.request.name, "")
+			}
+			response, err := tokenController.CreateToken(tc.request.name, tc.request.namespace, tc.request.expiration)
+			if tc.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(customerrors.ErrorWithStatusCode).StatusReason()
+
+				assert.Equal(t, tc.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+				// Since there is no TokenController running, no token is created so this is not worth much.
+				// TODO: Rework this when https://github.com/kubernetes-sigs/controller-runtime/pull/2969 is released.
+				assert.Equal(t, tc.want.response, response)
+
+			}
+		})
+	}
+}
+
+func TestRevokeToken(t *testing.T) {
+	namespaceName := testutils.TokenNamespace + "-revoke-token"
+	type requestParams struct {
+		name                 string
+		namespace            string
+		secretName           string
+		createServiceAccount bool
+	}
+	type want struct {
+		errorStatus metav1.StatusReason
+	}
+	cases := map[string]struct {
+		requestParams requestParams
+		want          want
+	}{
+		"ShouldSucceedRevokingToken": {
+			requestParams: requestParams{
+				name:                 testutils.ServiceAccountName,
+				namespace:            namespaceName,
+				secretName:           fmt.Sprintf("%s-%s", testutils.ServiceAccountName, testutils.TokenRequestSuffix),
+				createServiceAccount: true,
+			},
+			want: want{
+				errorStatus: metav1.StatusSuccess,
+			},
+		},
+		"ShouldFailRevokingTokenWithoutServiceAccount": {
+			requestParams: requestParams{
+				name:                 testutils.ServiceAccountName + testutils.NonExistentSuffix,
+				namespace:            namespaceName,
+				secretName:           fmt.Sprintf("%s-%s", testutils.ServiceAccountName+testutils.NonExistentSuffix, testutils.TokenRequestSuffix),
+				createServiceAccount: false,
+			},
+			want: want{
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+		"ShouldFailRevokingTokenWithoutSecret": {
+			requestParams: requestParams{
+				name:                 testutils.ServiceAccountName + "-1",
+				namespace:            namespaceName,
+				secretName:           "",
+				createServiceAccount: true,
+			},
+			want: want{
+				errorStatus: metav1.StatusReasonNotFound,
+			},
+		},
+	}
+	setup()
+	tokenController := NewTokenController(fakeClient, mocks.GinContext(), logger)
+	createTestNamespace(namespaceName, utils.AddManagedLabel(map[string]string{}))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.requestParams.createServiceAccount {
+				mocks.CreateTestServiceAccount(fakeClient, tc.requestParams.namespace, tc.requestParams.name, "")
+			}
+			if tc.requestParams.secretName != "" {
+				createTestSecret(tc.requestParams.secretName, tc.requestParams.namespace, utils.AddManagedLabel(map[string]string{}))
+			}
+			err := tokenController.RevokeToken(tc.requestParams.name, tc.requestParams.namespace)
+			if tc.want.errorStatus != metav1.StatusSuccess {
+				reason := err.(customerrors.ErrorWithStatusCode).StatusReason()
+				assert.Equal(t, tc.want.errorStatus, reason)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/routes/v1/doc/operation/common.go
+++ b/src/routes/v1/doc/operation/common.go
@@ -48,6 +48,8 @@ const (
 
 	logsKey     = "logs"
 	terminalKey = "terminal"
+
+	expirationSecondsKey = "expirationSeconds"
 )
 
 const (
@@ -66,4 +68,8 @@ const (
 	sessionIDKey = "SessionID"
 	rowsKey      = "rows"
 	colsKey      = "cols"
+)
+
+const (
+	defaultExampleSeconds = "3600"
 )

--- a/src/routes/v1/doc/operation/token.go
+++ b/src/routes/v1/doc/operation/token.go
@@ -11,19 +11,20 @@ import (
 )
 
 const (
-	serviceAccountTag  = "ServiceAccounts"
-	serviceAccountsKey = "serviceaccounts"
+	tokenTag  = "Tokens"
+	tokensKey = "token"
 )
 
-// AddGetServiceAccount adds the GetServiceAccount route to the OpenAPI scheme.
-func AddGetServiceAccount(api huma.API, registry huma.Registry) {
+// TODO: figure out if this function is neccessary. It is sort of confusing since this is relating to dockercfgTokens, not auth tokens.
+// AddGetToken adds the GetToken route to the OpenAPI scheme.
+func AddGetToken(api huma.API, registry huma.Registry) {
 	operation := &huma.Operation{
-		OperationID: "get-serviceaccount",
+		OperationID: "get-token",
 		Method:      http.MethodGet,
-		Tags:        []string{serviceAccountTag},
-		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName),
-		Summary:     "Get a specific ServiceAccount in a namespace",
-		Description: "Retrieves a specific ServiceAccount in a namespace",
+		Tags:        []string{tokenTag},
+		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}/%s", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName, tokensKey),
+		Summary:     "Get token of a ServiceAccount in a namespace",
+		Description: "Retrieves the token of a specific ServiceAccount in a namespace",
 		Parameters: []*huma.Param{
 			{
 				Name:     namespaceNameKey,
@@ -47,7 +48,7 @@ func AddGetServiceAccount(api huma.API, registry huma.Registry) {
 			strconv.Itoa(http.StatusOK): {
 				Content: map[string]*huma.MediaType{
 					applicationJSONKey: {
-						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.ServiceAccount{})),
+						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.TokenResponse{})),
 					},
 				},
 			},
@@ -71,15 +72,15 @@ func AddGetServiceAccount(api huma.API, registry huma.Registry) {
 	api.OpenAPI().AddOperation(operation)
 }
 
-// AddCreateServiceAccount adds the CreateServiceAccount route to the OpenAPI scheme.
-func AddCreateServiceAccount(api huma.API, registry huma.Registry) {
+// AddCreateToken adds the CreateToken route to the OpenAPI scheme.
+func AddCreateToken(api huma.API, registry huma.Registry) {
 	operation := &huma.Operation{
-		OperationID: "create-serviceaccount",
+		OperationID: "create-token",
 		Method:      http.MethodPost,
-		Tags:        []string{serviceAccountTag},
-		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName),
-		Summary:     "Create a ServiceAccount in a namespace",
-		Description: "Creates a new ServiceAccount in a specific namespace",
+		Tags:        []string{tokenTag},
+		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}/%s", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName, tokensKey),
+		Summary:     "Creates an auth token for a service account",
+		Description: "Creates an auth token for a service account in a namespace",
 		Parameters: []*huma.Param{
 			{
 				Name:     namespaceNameKey,
@@ -95,6 +96,13 @@ func AddCreateServiceAccount(api huma.API, registry huma.Registry) {
 				Schema:   huma.SchemaFromType(registry, reflect.TypeOf(types.ServiceAccountRequestUri{}.ServiceAccountName)),
 				Example:  defaultExample,
 			},
+			{
+				Name:     expirationSecondsKey,
+				In:       queryKey,
+				Required: false,
+				Schema:   huma.SchemaFromType(registry, reflect.TypeOf("")),
+				Example:  defaultExampleSeconds,
+			},
 		},
 		Security: []map[string][]string{
 			{bearerKey: {}},
@@ -103,7 +111,7 @@ func AddCreateServiceAccount(api huma.API, registry huma.Registry) {
 			strconv.Itoa(http.StatusOK): {
 				Content: map[string]*huma.MediaType{
 					applicationJSONKey: {
-						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.ServiceAccount{})),
+						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.TokenRequestResponse{})),
 					},
 				},
 			},
@@ -123,18 +131,19 @@ func AddCreateServiceAccount(api huma.API, registry huma.Registry) {
 			},
 		},
 	}
+
 	api.OpenAPI().AddOperation(operation)
 }
 
-// AddDeleteServiceAccount adds the DeleteServiceAccount route to the OpenAPI scheme.
-func AddDeleteServiceAccount(api huma.API, registry huma.Registry) {
+// AddRevokeToken adds the RevokeToken route to the OpenAPI scheme.
+func AddRevokeToken(api huma.API, registry huma.Registry) {
 	operation := &huma.Operation{
-		OperationID: "delete-serviceaccount",
+		OperationID: "revoke-token",
 		Method:      http.MethodDelete,
-		Tags:        []string{serviceAccountTag},
-		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName),
-		Summary:     "Deletes a ServiceAccount in a namespace",
-		Description: "Deletes a specific ServiceAccount in a specific namespace",
+		Tags:        []string{tokenTag},
+		Path:        fmt.Sprintf("/v1/%s/{%s}/%s/{%s}/%s", namespacesKey, namespaceNameKey, serviceAccountsKey, serviceAccountName, tokensKey),
+		Summary:     "Revokes the tokens for a ServiceAccount",
+		Description: "Revokes all tokens for a specific ServiceAccount in a namespace",
 		Parameters: []*huma.Param{
 			{
 				Name:     namespaceNameKey,
@@ -178,66 +187,5 @@ func AddDeleteServiceAccount(api huma.API, registry huma.Registry) {
 			},
 		},
 	}
-	api.OpenAPI().AddOperation(operation)
-}
-
-// AddGetServiceAccounts adds the GetServiceAccounts route to the OpenAPI scheme.
-func AddGetServiceAccounts(api huma.API, registry huma.Registry) {
-	operation := &huma.Operation{
-		OperationID: "get-serviceAccounts",
-		Method:      http.MethodGet,
-		Tags:        []string{serviceAccountTag},
-		Path:        fmt.Sprintf("/v1/%s/{%s}/%s", namespacesKey, namespaceNameKey, serviceAccountsKey),
-		Summary:     "Get all ServiceAccounts in a namespace",
-		Description: "Retrieves all ServiceAccounts in a specific namespace",
-		Parameters: []*huma.Param{
-			{
-				Name:    paginationPageKey,
-				In:      queryKey,
-				Schema:  huma.SchemaFromType(registry, reflect.TypeOf(types.PaginationParams{}.Page)),
-				Example: 1,
-			},
-			{
-				Name:    paginationLimitKey,
-				In:      queryKey,
-				Schema:  huma.SchemaFromType(registry, reflect.TypeOf(types.PaginationParams{}.Limit)),
-				Example: 1,
-			},
-			{
-				Name:     namespaceNameKey,
-				In:       pathKey,
-				Required: true,
-				Schema:   huma.SchemaFromType(registry, reflect.TypeOf(types.NamespaceUri{}.NamespaceName)),
-				Example:  defaultExample,
-			},
-		},
-		Security: []map[string][]string{
-			{bearerKey: {}},
-		},
-		Responses: map[string]*huma.Response{
-			strconv.Itoa(http.StatusOK): {
-				Content: map[string]*huma.MediaType{
-					applicationJSONKey: {
-						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.ServiceAccountOutput{})),
-					},
-				},
-			},
-			strconv.Itoa(http.StatusBadRequest): {
-				Content: map[string]*huma.MediaType{
-					applicationJSONKey: {
-						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.ErrorResponse{})),
-					},
-				},
-			},
-			strconv.Itoa(http.StatusInternalServerError): {
-				Content: map[string]*huma.MediaType{
-					applicationJSONKey: {
-						Schema: huma.SchemaFromType(registry, reflect.TypeOf(types.ErrorResponse{})),
-					},
-				},
-			},
-		},
-	}
-
 	api.OpenAPI().AddOperation(operation)
 }

--- a/src/routes/v1/setup.go
+++ b/src/routes/v1/setup.go
@@ -200,6 +200,12 @@ func setupNamespaceRoutes(api huma.API, r huma.Registry, v1 *gin.RouterGroup, to
 
 		serviceAccountsGroup.DELETE("/:serviceAccountName", DeleteServiceAccount())
 		operation.AddDeleteServiceAccount(api, r)
+
+		serviceAccountsGroup.POST("/:serviceAccountName/token", CreateToken())
+		operation.AddCreateToken(api, r)
+
+		serviceAccountsGroup.DELETE("/:serviceAccountName/token", RevokeToken())
+		operation.AddRevokeToken(api, r)
 	}
 }
 

--- a/src/routes/v1/tokens.go
+++ b/src/routes/v1/tokens.go
@@ -1,0 +1,76 @@
+package v1
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dana-team/platform-backend/src/customerrors"
+	"github.com/dana-team/platform-backend/src/types"
+
+	"github.com/dana-team/platform-backend/src/controllers"
+	"github.com/dana-team/platform-backend/src/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// tokenHandler wraps a handler function with context setup for tokenController.
+func tokenHandler(handler func(controller controllers.TokenController, c *gin.Context) (interface{}, error)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		kubeClient, err := middleware.GetKubeClient(c)
+		if middleware.AddErrorToContext(c, err) {
+			return
+		}
+
+		logger, err := middleware.GetLogger(c)
+		if middleware.AddErrorToContext(c, err) {
+			return
+		}
+
+		context := c.Request.Context()
+		tokenController := controllers.NewTokenController(kubeClient, context, logger)
+
+		result, err := handler(tokenController, c)
+		if middleware.AddErrorToContext(c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, result)
+	}
+}
+
+// CreateToken returns a Gin handler function for creating a service account token.
+func CreateToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var request types.ServiceAccountRequestUri
+		if err := c.BindUri(&request); err != nil {
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			return
+		}
+
+		var query types.CreateTokenQuery
+		if err := c.BindQuery(&query); err != nil {
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			return
+		}
+
+		tokenHandler(func(controller controllers.TokenController, c *gin.Context) (interface{}, error) {
+			return controller.CreateToken(request.ServiceAccountName, request.NamespaceName, query.ExpirationSeconds)
+		})(c)
+	}
+}
+
+// RevokeToken returns a Gin handler function for revoking the tokens for a service account.
+func RevokeToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var request types.ServiceAccountRequestUri
+		if err := c.BindUri(&request); err != nil {
+			middleware.AddErrorToContext(c, customerrors.NewValidationError(err.Error()))
+			return
+		}
+
+		tokenHandler(func(controller controllers.TokenController, c *gin.Context) (interface{}, error) {
+			name := request.ServiceAccountName
+			message := fmt.Sprintf("Revoked tokens for ServiceAccount %q", name)
+			return types.MessageResponse{Message: message}, controller.RevokeToken(request.ServiceAccountName, request.NamespaceName)
+		})(c)
+	}
+}

--- a/src/routes/v1/tokens_test.go
+++ b/src/routes/v1/tokens_test.go
@@ -1,0 +1,199 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/dana-team/platform-backend/src/controllers"
+
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	"github.com/dana-team/platform-backend/src/utils/testutils/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateToken(t *testing.T) {
+	namespaceName := testutils.TestNamespace + "-create-token"
+	type args struct {
+		serviceAccountName   string
+		namespaceName        string
+		createServiceAccount bool
+	}
+	type want struct {
+		statusCode int
+		response   map[string]interface{}
+	}
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldCreateToken": {
+			args: args{
+				serviceAccountName:   testutils.ServiceAccountName,
+				namespaceName:        namespaceName,
+				createServiceAccount: true,
+			},
+			want: want{
+				statusCode: http.StatusOK,
+				response: map[string]interface{}{
+					"token":   "",
+					"expires": time.Time{},
+				},
+			},
+		},
+		"ShouldNotCreateTokenWhenServiceAccountDoesNotExist": {
+			args: args{
+				serviceAccountName:   testutils.ServiceAccountName + testutils.NonExistentSuffix,
+				namespaceName:        namespaceName,
+				createServiceAccount: false,
+			},
+			want: want{
+				statusCode: http.StatusNotFound,
+				response: map[string]interface{}{
+					testutils.ErrorKey: fmt.Sprintf("%s, %s",
+						fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, testutils.ServiceAccountName+testutils.NonExistentSuffix, namespaceName),
+						fmt.Sprintf("serviceaccounts %q not found", testutils.ServiceAccountName+testutils.NonExistentSuffix),
+					),
+					testutils.ReasonKey: testutils.ReasonNotFound,
+				},
+			},
+		},
+	}
+	setup()
+	mocks.CreateTestNamespace(fakeClient, namespaceName)
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := url.Values{}
+
+			if tc.args.createServiceAccount {
+				mocks.CreateTestServiceAccount(fakeClient, tc.args.namespaceName, tc.args.serviceAccountName, "")
+			}
+
+			baseURI := fmt.Sprintf("/v1/namespaces/%s/serviceaccounts/%s/token", tc.args.namespaceName, tc.args.serviceAccountName)
+			request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s?%s", baseURI, params.Encode()), nil)
+			assert.NoError(t, err)
+			writer := httptest.NewRecorder()
+			router.ServeHTTP(writer, request)
+
+			assert.Equal(t, tc.want.statusCode, writer.Code)
+
+			var response map[string]interface{}
+			err = json.Unmarshal(writer.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			wantResponseJSON, err := json.Marshal(tc.want.response)
+			assert.NoError(t, err)
+			var wantResponseNormalized map[string]interface{}
+			err = json.Unmarshal(wantResponseJSON, &wantResponseNormalized)
+			assert.NoError(t, err)
+			assert.Equal(t, wantResponseNormalized, response)
+		})
+	}
+}
+
+func TestRevokeToken(t *testing.T) {
+	namespaceName := testutils.TestNamespace + "-revoke-token"
+	type args struct {
+		serviceAccountName   string
+		namespaceName        string
+		secretName           string
+		createServiceAccount bool
+	}
+	type want struct {
+		statusCode int
+		response   map[string]interface{}
+	}
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"ShouldRevokeToken": {
+			args: args{
+				serviceAccountName:   testutils.ServiceAccountName,
+				namespaceName:        namespaceName,
+				secretName:           fmt.Sprintf("%s-%s", testutils.ServiceAccountName, testutils.TokenRequestSuffix),
+				createServiceAccount: true,
+			},
+			want: want{
+				statusCode: http.StatusOK,
+				response: map[string]interface{}{
+					"message": fmt.Sprintf("Revoked tokens for ServiceAccount %q", testutils.ServiceAccountName),
+				},
+			},
+		},
+		"ShouldNotRevokeTokenWhenSecretNotFound": {
+			args: args{
+				serviceAccountName:   testutils.ServiceAccountName + "-no-secret",
+				namespaceName:        namespaceName,
+				secretName:           "",
+				createServiceAccount: true,
+			},
+			want: want{
+				statusCode: http.StatusNotFound,
+				response: map[string]interface{}{
+					testutils.ErrorKey: fmt.Sprintf("%s, %s",
+						fmt.Sprintf(controllers.ErrCouldNotGetTokenRequestSecret, testutils.ServiceAccountName+"-no-secret", namespaceName),
+						fmt.Sprintf("secrets %q not found", fmt.Sprintf("%s-%s", testutils.ServiceAccountName+"-no-secret", testutils.TokenRequestSuffix)),
+					),
+					testutils.ReasonKey: testutils.ReasonNotFound,
+				},
+			},
+		},
+		"ShouldNotRevokeTokenWhenServiceAccountDoesNotExist": {
+			args: args{
+				serviceAccountName:   testutils.ServiceAccountName + testutils.NonExistentSuffix,
+				namespaceName:        namespaceName,
+				secretName:           fmt.Sprintf("%s-%s", testutils.ServiceAccountName+testutils.NonExistentSuffix, testutils.TokenRequestSuffix),
+				createServiceAccount: false,
+			},
+			want: want{
+				statusCode: http.StatusNotFound,
+				response: map[string]interface{}{
+					testutils.ErrorKey: fmt.Sprintf("%s, %s",
+						fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, testutils.ServiceAccountName+testutils.NonExistentSuffix, namespaceName),
+						fmt.Sprintf("serviceaccounts %q not found", testutils.ServiceAccountName+testutils.NonExistentSuffix),
+					),
+					testutils.ReasonKey: testutils.ReasonNotFound,
+				},
+			},
+		},
+	}
+	setup()
+	mocks.CreateTestNamespace(fakeClient, namespaceName)
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := url.Values{}
+
+			if tc.args.createServiceAccount {
+				mocks.CreateTestServiceAccount(fakeClient, tc.args.namespaceName, tc.args.serviceAccountName, "")
+			}
+			if tc.args.secretName != "" {
+				mocks.CreateTestSecret(fakeClient, tc.args.secretName, tc.args.namespaceName)
+			}
+			baseURI := fmt.Sprintf("/v1/namespaces/%s/serviceaccounts/%s/token", tc.args.namespaceName, tc.args.serviceAccountName)
+			request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s?%s", baseURI, params.Encode()), nil)
+			assert.NoError(t, err)
+			writer := httptest.NewRecorder()
+			router.ServeHTTP(writer, request)
+
+			assert.Equal(t, tc.want.statusCode, writer.Code)
+
+			var response map[string]interface{}
+			err = json.Unmarshal(writer.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			wantResponseJSON, err := json.Marshal(tc.want.response)
+			assert.NoError(t, err)
+			var wantResponseNormalized map[string]interface{}
+			err = json.Unmarshal(wantResponseJSON, &wantResponseNormalized)
+			assert.NoError(t, err)
+			assert.Equal(t, wantResponseNormalized, response)
+		})
+	}
+}

--- a/src/types/serviceaccounts.go
+++ b/src/types/serviceaccounts.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 type ServiceAccountRequestUri struct {
 	NamespaceName      string `uri:"namespaceName" json:"namespaceName" binding:"required"`
 	ServiceAccountName string `uri:"serviceAccountName" json:"serviceAccountName" binding:"required"`
@@ -17,5 +19,15 @@ type ServiceAccountOutput struct {
 }
 
 type ServiceAccount struct {
-	Name string `json:"name" binding:"required"`
+	Name  string `json:"name" binding:"required"`
+	Token string `json:"token,omitempty"`
+}
+
+type TokenRequestResponse struct {
+	Token   string    `json:"token"`
+	Expires time.Time `json:"expires,omitempty"`
+}
+
+type CreateTokenQuery struct {
+	ExpirationSeconds string `form:"expirationSeconds" json:"expirationSeconds"`
 }

--- a/src/utils/labels.go
+++ b/src/utils/labels.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 )
 

--- a/src/utils/testutils/consts.go
+++ b/src/utils/testutils/consts.go
@@ -37,6 +37,8 @@ const (
 	SecretNamespace        = SecretName + "-ns"
 	KeyField               = "key"
 	ValueField             = "value"
+	TokenName              = "token"
+	TokenNamespace         = TokenName + "-ns"
 )
 
 const (
@@ -54,6 +56,7 @@ const (
 const (
 	ServiceAccountsKey = "serviceAccounts"
 	TokenKey           = "token"
+	ExpiresKey         = "expires"
 	Secret             = "Secret"
 	V1                 = "v1"
 	Value              = "value"
@@ -171,5 +174,7 @@ const (
 )
 
 const (
-	ServiceAccountParam = "serviceaccounts"
+	ServiceAccountParam    = "serviceaccounts"
+	ExpirationSecondsParam = "expirationSeconds"
+	TokenRequestSuffix     = "token-request"
 )

--- a/test/e2e_tests/tokens.go
+++ b/test/e2e_tests/tokens.go
@@ -1,0 +1,141 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dana-team/platform-backend/src/controllers"
+	"github.com/dana-team/platform-backend/src/utils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validate ServiceAccount token routes and functionality", func() {
+	var namespaceName, serviceAccountName string
+
+	BeforeEach(func() {
+		namespaceName = generateName(e2eNamespace)
+		createTestNamespace(k8sClient, namespaceName)
+
+		serviceAccountName = generateName(testServiceAccountName)
+		tokenRequestSecret := fmt.Sprintf("%s-token-request", serviceAccountName)
+		createTestSecret(k8sClient, tokenRequestSecret, namespaceName)
+		CreateTestServiceAccount(k8sClient, serviceAccountName, namespaceName, "token-secret", "value", "docker-cfg")
+		Eventually(func() bool {
+			tokenSecret := getServiceAccountTokenSecret(k8sClient, serviceAccountName, namespaceName)
+			_, ok := tokenSecret.Data[testutils.TokenKey]
+			return ok
+		}, testutils.Timeout, testutils.Interval).Should(BeTrue())
+	})
+
+	Context("Validate create token route", func() {
+		It("Should create a token for a ServiceAccount", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+
+			Expect(status).Should(Equal(http.StatusOK))
+			Expect(response[testutils.TokenKey]).ShouldNot(BeEmpty())
+		})
+		It("Should create a multiple tokens for a ServiceAccount", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName)
+			firstStatus, firstResponse := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+
+			Expect(firstStatus).Should(Equal(http.StatusOK))
+			Expect(firstResponse[testutils.TokenKey]).ShouldNot(BeEmpty())
+			firstToken := firstResponse[testutils.TokenKey].(string)
+
+			// Sleep for 1 second to ensure that the requests are seperated
+			time.Sleep(1 * time.Second)
+
+			secondStatus, secondResponse := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+			Expect(secondStatus).Should(Equal(http.StatusOK))
+			Expect(secondResponse[testutils.TokenKey]).ShouldNot(BeEmpty())
+			secondToken := secondResponse[testutils.TokenKey].(string)
+
+			Expect(firstToken).ShouldNot(Equal(secondToken))
+		})
+
+		It("Should create a token with a different expiration time depending on query params", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token?%s=%s", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName, testutils.ExpirationSecondsParam, "7200")
+			status, response := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+
+			Expect(status).Should(Equal(http.StatusOK))
+			Expect(response[testutils.TokenKey]).ShouldNot(BeEmpty())
+			laterExpiration, err := time.Parse(time.RFC3339, response[testutils.ExpiresKey].(string))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			uri = fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token?%s=%s", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName, testutils.ExpirationSecondsParam, "3600")
+			status, response = performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+			Expect(status).Should(Equal(http.StatusOK))
+			Expect(response[testutils.TokenKey]).ShouldNot(BeEmpty())
+			earlierExpiration, err := time.Parse(time.RFC3339, response[testutils.ExpiresKey].(string))
+			Expect(err).ShouldNot(HaveOccurred())
+			isActualAfterExpected := laterExpiration.After(earlierExpiration)
+			Expect(isActualAfterExpected).Should(BeTrue())
+		})
+
+		It("Should handle an invalid string in expirationSeconds param", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token?%s=%s", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName, testutils.ExpirationSecondsParam, testutils.TestName)
+			status, _ := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+
+			Expect(status).Should(Equal(http.StatusBadRequest))
+		})
+		It("Should handle a not found ServiceAccount in a namespace", func() {
+			tokenRequestSecret := fmt.Sprintf("%s-token-request", serviceAccountName+testutils.NonExistentSuffix)
+			createTestSecret(k8sClient, tokenRequestSecret, namespaceName)
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName+testutils.NonExistentSuffix)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodPost, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf(controllers.ErrCouldNotCreateTokenRequest, serviceAccountName+testutils.NonExistentSuffix, namespaceName),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+	})
+
+	Context("Validate revoke token route", func() {
+		It("Should revoke a token for a ServiceAccount", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.MessageKey: fmt.Sprintf("Revoked tokens for ServiceAccount %q", serviceAccountName),
+			}
+
+			Expect(status).Should(Equal(http.StatusOK))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a not found ServiceAccount in a namespace", func() {
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, serviceAccountName+testutils.NonExistentSuffix)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf(controllers.ErrCouldNotGetServiceAccount, serviceAccountName+testutils.NonExistentSuffix, namespaceName),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+
+		It("Should handle a not found token request secret in a namespace", func() {
+			newServiceAccount := generateName(testServiceAccountName)
+			CreateTestServiceAccount(k8sClient, newServiceAccount, namespaceName, "token-secret", "value", "docker-cfg")
+			uri := fmt.Sprintf("%s/v1/namespaces/%s/%s/%s/token", platformURL, namespaceName, testutils.ServiceAccountParam, newServiceAccount)
+			status, response := performHTTPRequest(httpClient, nil, http.MethodDelete, uri, "", "", userToken)
+
+			expectedResponse := map[string]interface{}{
+				testutils.ErrorKey:  fmt.Sprintf(controllers.ErrCouldNotGetTokenRequestSecret, newServiceAccount, namespaceName),
+				testutils.ReasonKey: testutils.ReasonNotFound,
+			}
+
+			Expect(status).Should(Equal(http.StatusNotFound))
+			compareResponses(response, expectedResponse)
+		})
+	})
+})


### PR DESCRIPTION
With this PR, tokens can be generated for a specific ServiceAccounts using the TokenRequest API. These tokens are bound to a secret which is created for each service account that is created. These tokens can also be revoked by deleteing the token and re-creating it (for future use).